### PR TITLE
Developer message by property, addMessage method

### DIFF
--- a/LARAGENT.md
+++ b/LARAGENT.md
@@ -217,7 +217,7 @@ $agent
 // Setup agent with tools and structured output
 $agent->setTools([$weatherTool])
     ->structured($weatherSchema)
-    ->withInstructions('You are a weather assistant')
+    ->withInstructions('You are a weather assistant', false) // false = use system role, true = use developer role
     ->withMessage(Message::user('What\'s the weather in London?'));
 
 // Run the conversation

--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ public function withImages(array $imageUrls);
 public function withModel(string $model);
 
 /**
+ * Add custom message to the chat history with a needed role
+ * @param MessageInterface Easily created with message class: Message::system('Your message here')
+ */
+public function addMessage(MessageInterface $message);
+
+/**
  * Clear the chat history 
  * This removes all messages from the chat history
  */
@@ -522,6 +528,8 @@ protected $parallelToolCalls;
 /** @var array - List of tool classes to be registered with the agent */
 protected $tools = [];
 ```
+
+_Note: You can set parallelToolCalls to null in case you want to remove from request, since some models do not support parallel tool calls property._
 
 There are three ways to create and register tools in your agent:
 
@@ -692,6 +700,13 @@ Some LLM drivers such as OpenAI provide additional data with the response, such 
 protected $saveChatKeys;
 ```
 By default it is true, since it is required for [chat history bunch clearing](#clear-chat-history) command to work.
+
+**developerRoleForInstructions**
+```php
+/** @var bool - Use developer role for instructions */
+protected $developerRoleForInstructions;
+```
+By default it is disabled, but you can turn it on by setting it to true in your agent.
 
 #### Creating Custom Chat History
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -7,6 +7,7 @@ use LarAgent\Attributes\Tool as ToolAttribute;
 use LarAgent\Core\Contracts\ChatHistory as ChatHistoryInterface;
 use LarAgent\Core\Contracts\LlmDriver as LlmDriverInterface;
 use LarAgent\Core\Contracts\Message as MessageInterface;
+use LarAgent\Core\Contracts\Tool as ToolInterface;
 use LarAgent\Core\DTO\AgentDTO;
 use LarAgent\Core\Traits\Events;
 
@@ -51,6 +52,9 @@ class Agent
     /** @var string */
     protected $providerName = '';
 
+    /** @var bool */
+    protected $developerRoleForInstructions = false;
+
     // Driver configs
 
     /** @var string */
@@ -85,7 +89,7 @@ class Agent
     /** @var int */
     protected $reinjectInstructionsPer;
 
-    /** @var bool */
+    /** @var ?bool */
     protected $parallelToolCalls;
 
     /** @var string */
@@ -179,7 +183,7 @@ class Agent
         }
 
         $this->agent
-            ->withInstructions($this->instructions())
+            ->withInstructions($this->instructions(), $this->developerRoleForInstructions)
             ->withMessage($message)
             ->setTools($this->getTools());
 
@@ -409,6 +413,13 @@ class Agent
         return $this;
     }
 
+    public function addMessage(MessageInterface $message): static
+    {
+        $this->chatHistory()->addMessage($message);
+
+        return $this;
+    }
+
     /**
      * Convert Agent to DTO
      * // @todo mention DTO in the documentation as state for events
@@ -524,14 +535,14 @@ class Agent
         $config = [
             'model' => $this->model(),
         ];
-        if (isset($this->maxCompletionTokens)) {
-            $config['max_completion_tokens'] = $this->maxCompletionTokens;
+        if (property_exists($this, 'maxCompletionTokens')) {
+            $config['maxCompletionTokens'] = $this->maxCompletionTokens;
         }
-        if (isset($this->temperature)) {
+        if (property_exists($this, 'temperature')) {
             $config['temperature'] = $this->temperature;
         }
-        if (isset($this->parallelToolCalls)) {
-            $config['parallel_tool_calls'] = $this->parallelToolCalls;
+        if (property_exists($this, 'parallelToolCalls')) {
+            $config['parallelToolCalls'] = $this->parallelToolCalls;
         }
 
         return $config;

--- a/src/Drivers/OpenAi/OpenAiCompatible.php
+++ b/src/Drivers/OpenAi/OpenAiCompatible.php
@@ -14,13 +14,15 @@ class OpenAiCompatible extends LlmDriver implements LlmDriverInterface
 {
     protected mixed $client;
 
+    protected string $default_url = 'https://api.openai.com/v1';
+
     public function __construct(array $provider = [])
     {
         parent::__construct($provider);
-        if ($provider['api_key'] && $provider['api_url']) {
-            $this->client = $this->buildClient($provider['api_key'], $provider['api_url']);
+        if ($provider['api_key']) {
+            $this->client = $this->buildClient($provider['api_key'], $provider['api_url'] ?? $this->default_url);
         } else {
-            throw new \Exception('OpenAiCompatible driver requires api_key and api_url in provider settings.');
+            throw new \Exception('OpenAiCompatible driver requires api_key in provider settings.');
         }
     }
 

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -3,8 +3,9 @@
 namespace LarAgent;
 
 use LarAgent\Core\Abstractions\Tool as AbstractTool;
+use LarAgent\Core\Contracts\Tool as ToolInterface;
 
-class Tool extends AbstractTool
+class Tool extends AbstractTool implements ToolInterface
 {
     protected mixed $callback = null;
 

--- a/test-agent.php
+++ b/test-agent.php
@@ -16,7 +16,7 @@ function config(string $key): mixed
             'model' => 'gpt-4o',
             'api_key' => $yourApiKey,
             'default_context_window' => 50000,
-            'default_max_completion_tokens' => 100,
+            'default_max_completion_tokens' => 1000,
             'default_temperature' => 1,
         ],
     ][$key];
@@ -62,6 +62,8 @@ class WeatherAgent extends LarAgent\Agent
 
     protected $provider = 'default';
 
+    protected $model = 'o1-2024-12-17';
+
     // Tool by classes
     protected $tools = [
         // WeatherTool::class
@@ -69,6 +71,11 @@ class WeatherAgent extends LarAgent\Agent
 
     // To not saves chat keys to memory, by default = true
     protected $saveChatKeys = false;
+
+    // Switch to developer role for instructions
+    // protected $developerRoleForInstructions = true;
+
+    protected $parallelToolCalls = null;
 
     protected $history = 'in_memory';
 


### PR DESCRIPTION
Added:
- Agent's property `$developerRoleForInstructions` to use developer role message (Contributed by @yannelli) for your agent
- Agent's chainable method `addMessage(MessageInterface $message)` to add any type of custom message in chat history
```php
TestAgent::for('chat_key')->addMesage(Message::system('Additional instructions here'))->respond($userMessage);
```
- NULL value for `$parallelToolCalls` property to remove `parallel_tool_calls` property from request (Needed for models not supporting given property)

What does it mean? You can now use the reasoning models in your agents!
![Screenshot_406](https://github.com/user-attachments/assets/4eabfe4e-c56b-41ba-9a1e-c304ded1fdc4)
