### PR TITLE
Made withTool and removeTool methods more flexible

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -418,6 +418,7 @@ class Agent
             if (is_string($tool) && class_exists($tool)) {
                 return new $tool;
             }
+
             return $tool;
         }, $this->tools);
 
@@ -502,6 +503,7 @@ class Agent
                 return true;
             }
             $this->onToolChange($existingTool, false);
+
             return false;
         });
 
@@ -511,8 +513,9 @@ class Agent
     private function getToolName(string|ToolInterface $tool): string
     {
         if (is_string($tool)) {
-            return class_exists($tool) ? (new $tool())->getName() : $tool;
+            return class_exists($tool) ? (new $tool)->getName() : $tool;
         }
+
         return $tool->getName();
     }
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -415,7 +415,12 @@ class Agent
     {
         // Get tools from $tools property (class names)
         $classTools = array_map(function ($tool) {
-            return new $tool;
+            if (is_string($tool) && class_exists($tool)) {
+                return new $tool;
+            }
+            if ($tool instanceof ToolInterface) {
+                return $tool;
+            }
         }, $this->tools);
 
         // Get tools from registerTools method (instances)
@@ -479,16 +484,25 @@ class Agent
         });
     }
 
-    public function withTool(ToolInterface $tool): static
+    public function withTool(string|ToolInterface $tool): static
     {
+        if (is_string($tool) && class_exists($tool)) {
+            $tool = new $tool();
+        }
         $this->tools[] = $tool;
         $this->onToolChange($tool, true);
 
         return $this;
     }
 
-    public function removeTool(string $name): static
+    public function removeTool(string|ToolInterface $name): static
     {
+        if (is_string($name) && class_exists($name)) {
+            $name = (new $name())->getName();
+        }
+        if ($name instanceof ToolInterface) {
+            $name = $name->getName();
+        }
         foreach ($this->tools as $key => $tool) {
             if ($tool->getName() === $name) {
                 unset($this->tools[$key]);


### PR DESCRIPTION
This PR improves the flexibility and reliability of tool management within the agent system and refines related tests. The changes address initialisation issues, enhance type safety, and ensure robust handling of tool instances and class references.

### Key Change is flexibility in the tools management for an agent. 
Now you can add a tool at runtime using
1. With newly created tool object
```php
$tool = Tool::create('test_tool', 'Test tool')->setCallback(fn () => 'test');
$agent->withTool($tool);
```
2. With the predefined tool class
```php
$agent->withTool(WeatherTool::class);
```
And you can remove tools on runtime:
1. With tool name
```php
// Remove tool by name
$agent->removeTool('get_current_weather');
```
2. With the tool object
```php
$tool = Tool::create('test_tool', 'Test tool')->setCallback(fn () => 'test');
$agent->withTool($tool);
if (!$needsTool) {
    $agent->removeTool($tool);
}
```
3. With the tool class
```php
$agent->removeTool(WeatherTool::class);
```

### Testing
All relevant tests in AgentTest.php and related suites continue to pass, confirming that tool management works as expected for both class references and direct instances.