### PR TITLE
Added Gemini driver, API key & URL properties to Agent class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^8.3",
         "guzzlehttp/guzzle": "^7.9",
         "illuminate/contracts": "^10.0||^11.0||^12.0",
-        "openai-php/client": "^0.10.3",
+        "openai-php/client": "^0.13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {

--- a/config/laragent.php
+++ b/config/laragent.php
@@ -29,7 +29,7 @@ return [
      * You can add more providers in array
      * by copying the 'default' provider
      * and changing the name and values
-     * 
+     *
      * You can remove any other providers
      * which your project doesn't need
      */

--- a/config/laragent.php
+++ b/config/laragent.php
@@ -29,14 +29,34 @@ return [
      * You can add more providers in array
      * by copying the 'default' provider
      * and changing the name and values
+     * 
+     * You can remove any other providers
+     * which your project doesn't need
      */
     'providers' => [
         'default' => [
             'label' => 'openai',
             'api_key' => env('OPENAI_API_KEY'),
+            'driver' => \LarAgent\Drivers\OpenAi\OpenAiDriver::class,
             'default_context_window' => 50000,
             'default_max_completion_tokens' => 10000,
             'default_temperature' => 1,
         ],
+
+        'gemini' => [
+            'label' => 'gemini',
+            'api_key' => env('GEMINI_API_KEY'),
+            'driver' => \LarAgent\Drivers\OpenAi\GeminiDriver::class,
+            'default_context_window' => 1000000,
+            'default_max_completion_tokens' => 10000,
+            'default_temperature' => 1,
+        ],
     ],
+
+    /**
+     * Fallback provider to use when any provider fails
+     * Fallback currently works only for respond method
+     * In case of streaming, No auto switch to fallback
+     */
+    'fallback_provider' => 'default',
 ];

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -197,10 +197,11 @@ class Agent
             } else {
                 // Run fallback provider
                 $this->changeProvider($fallbackProvider);
+
                 return $this->respond($message);
             }
         }
-        
+
         $this->onConversationEnd($response);
 
         return $response;

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -192,6 +192,13 @@ class Agent
             $this->onEngineError($th);
             // Run fallback provider
             $fallbackProvider = config('laragent.fallback_provider');
+
+            // Throw error if there is no fallback provider
+            if (!$fallbackProvider) {
+                throw $th;
+            }
+
+            // Throw error if fallback provider is same as current provider
             if ($fallbackProvider === $this->provider) {
                 throw $th;
             } else {
@@ -365,11 +372,17 @@ class Agent
         return $this->model;
     }
 
+    /**
+     * Dynamically set the API Key for the driver
+     */
     public function getApiKey()
     {
         return $this->apiKey;
     }
 
+    /**
+     * Dynamically set the API URL for the driver
+     */
     public function getApiUrl()
     {
         return $this->apiUrl;

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -194,7 +194,7 @@ class Agent
             $fallbackProvider = config('laragent.fallback_provider');
 
             // Throw error if there is no fallback provider
-            if (!$fallbackProvider) {
+            if (! $fallbackProvider) {
                 throw $th;
             }
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -442,7 +442,6 @@ class Agent
         $registeredTools = $this->registerTools();
 
         $attributeTools = $this->buildToolsFromAttributeMethods();
-        // print_r($attributeTools);
 
         // Merge both arrays
         return array_merge($classTools, $registeredTools, $attributeTools);
@@ -676,7 +675,6 @@ class Agent
         $this->setupDriverConfigs($provider);
 
         $settings = array_merge($provider, $this->buildConfigsFromAgent());
-        print_r($settings);
         $this->initDriver($settings);
     }
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -61,6 +61,12 @@ class Agent
     /** @var string */
     protected $model;
 
+    /** @var string */
+    protected $apiKey;
+
+    /** @var string */
+    protected $apiUrl;
+
     /** @var int */
     protected $contextWindowSize;
 
@@ -331,6 +337,16 @@ class Agent
     public function model()
     {
         return $this->model;
+    }
+
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    public function getApiUrl()
+    {
+        return $this->apiUrl;
     }
 
     /**
@@ -612,6 +628,13 @@ class Agent
 
     protected function setupDriverConfigs(array $providerData): void
     {
+        if (! isset($this->apiKey) && isset($providerData['api_key'])) {
+            $this->apiKey = $providerData['api_key'];
+        }
+        if (! isset($this->apiUrl) && isset($providerData['api_url'])) {
+            $this->apiUrl = $providerData['api_url'];
+        }
+
         if (! isset($this->model) && isset($providerData['model'])) {
             $this->model = $providerData['model'];
         }
@@ -652,21 +675,29 @@ class Agent
         $this->providerName = $provider['name'] ?? '';
         $this->setupDriverConfigs($provider);
 
-        $settings = array_merge($provider, $this->buildConfigsForLaragent());
-
+        $settings = array_merge($provider, $this->buildConfigsFromAgent());
+        print_r($settings);
         $this->initDriver($settings);
     }
 
     protected function setupAgent(): void
     {
-        $config = $this->buildConfigsForLaragent();
+        $config = $this->buildConfigsFromAgent();
         $this->agent = LarAgent::setup($this->llmDriver, $this->chatHistory, $config);
     }
 
-    protected function buildConfigsForLaragent()
+    /**
+     * Build configuration array from agent properties.
+     * Overrides provider data with ageent properties.
+     *
+     * @return array The configuration array with model, API key, API URL, and optional parameters.
+     */
+    protected function buildConfigsFromAgent(): array
     {
         $config = [
             'model' => $this->model(),
+            'api_key' => $this->getApiKey(),
+            'api_url' => $this->getApiUrl(),
         ];
         if (property_exists($this, 'maxCompletionTokens')) {
             $config['maxCompletionTokens'] = $this->maxCompletionTokens;

--- a/src/Commands/AgentChatCommand.php
+++ b/src/Commands/AgentChatCommand.php
@@ -18,8 +18,9 @@ class AgentChatCommand extends Command
 
         // Try both namespaces
         $agentClass = $this->findAgentClass($agentName);
-        if (!$agentClass) {
+        if (! $agentClass) {
             $this->error("Agent not found: {$agentName}");
+
             return 1;
         }
 
@@ -56,7 +57,7 @@ class AgentChatCommand extends Command
         $namespaces = config('laragent.namespaces');
 
         foreach ($namespaces as $namespace) {
-            $fqcn = $namespace . $agentName;
+            $fqcn = $namespace.$agentName;
             if (class_exists($fqcn)) {
                 return $fqcn;
             }

--- a/src/Core/Abstractions/LlmDriver.php
+++ b/src/Core/Abstractions/LlmDriver.php
@@ -75,6 +75,12 @@ abstract class LlmDriver implements LlmDriverInterface
         return ! empty($this->getResponseSchema());
     }
 
+    /**
+     * Get the provider data merged with the model defined settings.
+     * Some Model settings override provider settings.
+     *
+     * @return array The settings.
+     */
     public function getSettings(): array
     {
         return $this->settings;

--- a/src/Core/Traits/Events.php
+++ b/src/Core/Traits/Events.php
@@ -146,4 +146,12 @@ trait Events
     {
         // Triggered when the agent is being terminated
     }
+
+    /**
+     * Event triggered when an engine error occurs.
+     */
+    protected function onEngineError(\Throwable $th)
+    {
+        // Triggered when an engine error occurs
+    }
 }

--- a/src/Drivers/OpenAi/GeminiDriver.php
+++ b/src/Drivers/OpenAi/GeminiDriver.php
@@ -2,8 +2,6 @@
 
 namespace LarAgent\Drivers\OpenAi;
 
-use OpenAI;
-
 class GeminiDriver extends OpenAiCompatible
 {
     protected string $default_url = 'https://generativelanguage.googleapis.com/v1beta/openai';

--- a/src/Drivers/OpenAi/GeminiDriver.php
+++ b/src/Drivers/OpenAi/GeminiDriver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LarAgent\Drivers\OpenAi;
+
+use OpenAI;
+
+class GeminiDriver extends OpenAiCompatible
+{
+    protected string $default_url = 'https://generativelanguage.googleapis.com/v1beta/openai';
+
+    public function __construct(array $provider = [])
+    {
+        parent::__construct($provider);
+        if ($provider['api_key']) {
+            $this->client = $this->buildClient($provider['api_key'], $provider['api_url'] ?? $this->default_url);
+        } else {
+            throw new \Exception('GeminiDriver driver requires api_key in provider settings.');
+        }
+    }
+}

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -233,9 +233,9 @@ it('excludes parallel_tool_calls from config when set to null', function () {
     $tool = Tool::create('test_tool', 'Test tool')->setCallback(fn () => 'test');
     $agent->withTool($tool);
 
-    $buildConfigsForLaragent = $reflection->getMethod('buildConfigsForLaragent');
-    $buildConfigsForLaragent->setAccessible(true);
-    $config = $buildConfigsForLaragent->invoke($agent);
+    $buildConfigsFromAgent = $reflection->getMethod('buildConfigsFromAgent');
+    $buildConfigsFromAgent->setAccessible(true);
+    $config = $buildConfigsFromAgent->invoke($agent);
 
     expect($config)->toHaveKey('parallelToolCalls')
         ->and($config['parallelToolCalls'])->toBeNull();


### PR DESCRIPTION
Key features added: 

- Gemini Driver: `LarAgent\Drivers\OpenAi\GeminiDriver::class`
- Possibility to set `$apiKey` & `$apiUrl` properties per agent
- `getApiUrl` & `getApiKey` methods - allowing easier setup via custom logic (For example, setting them from DB)
- Gemini provider in the starting config file
- Fallback provider - if the current provider fails for any reason, it will try the same call with the fallback provider (Works only with non-streaming calls)
- `onEngineError` event, which fires if current provider fails to return response

