### PR TITLE
Ensures the current message is cleared after processing tool calls

### DIFF
--- a/src/LarAgent.php
+++ b/src/LarAgent.php
@@ -524,6 +524,9 @@ class LarAgent
                 return $this->runStreamed();
             }
 
+            // Reset message to null to skip adding it again in chat history
+            $this->message = null;
+
             return $this->run();
         }
 

--- a/src/LarAgent.php
+++ b/src/LarAgent.php
@@ -590,7 +590,6 @@ class LarAgent
             }
             $this->chatHistory->addMessage($result);
         }
-
     }
 
     protected function processToolCall(ToolCallInterface $toolCall): ?ToolResultMessage

--- a/tests/LarAgentTest.php
+++ b/tests/LarAgentTest.php
@@ -87,7 +87,7 @@ it('can run with tools', function () {
         ->setRequired('location')
         ->setMetaData(['sent_at' => '2024-01-01'])
         ->setCallback(function ($location, $unit = 'fahrenheit') {
-            return 'The weather in '.$location.' is 72 degrees '.$unit;
+            return 'The weather in ' . $location . ' is 72 degrees ' . $unit;
         });
 
     $userMessage = Message::user('What\'s the weather like in Boston and Los Angeles? I prefer celsius');
@@ -98,7 +98,7 @@ it('can run with tools', function () {
         ->withMessage($userMessage);
 
     $agent->afterResponse(function ($agent, $message) {
-        $message->setContent($message.'. Checked at 2024-01-01');
+        $message->setContent($message . '. Checked at 2024-01-01');
     });
 
     $driver->addMockResponse('tool_calls', [
@@ -119,6 +119,9 @@ it('can run with tools', function () {
     // Ensure LarAgent mutates history correctly
     $history = $chatHistory->toArray();
     expect($history)->toContain($userMessage->toArray());
+
+    // Ensure the current message is cleared correctly
+    expect($agent->getCurrentMessage())->toBeNull();
 });
 
 it('excludes parallel_tool_calls from config when set to null', function () {
@@ -127,7 +130,7 @@ it('excludes parallel_tool_calls from config when set to null', function () {
     $agent = LarAgent::setup($driver, $chatHistory);
 
     $agent->setParallelToolCalls(null);
-    $tool = Tool::create('test_tool', 'Test tool')->setCallback(fn () => 'test');
+    $tool = Tool::create('test_tool', 'Test tool')->setCallback(fn() => 'test');
     $agent->setTools([$tool]);
 
     $reflection = new ReflectionClass($agent);


### PR DESCRIPTION
This PR ensures the current message is cleared/reset after processing of tool calls (when streaming mode is NOT enabled).

This change ensures that before re-running the agent, we do not add another instance of the user message that triggered the tool calls - see issue https://github.com/MaestroError/LarAgent/issues/31

