### PR TITLE
Fix reinject instructions methods typo

### DIFF
--- a/src/LarAgent.php
+++ b/src/LarAgent.php
@@ -106,12 +106,12 @@ class LarAgent
         return $this;
     }
 
-    public function getReinjectInstuctionsPer(): int
+    public function getReinjectInstructionsPer(): int
     {
         return $this->reinjectInstructionsPer;
     }
 
-    public function setReinjectInstuctionsPer(int $reinjectInstructionsPer): self
+    public function setReinjectInstructionsPer(int $reinjectInstructionsPer): self
     {
         $this->reinjectInstructionsPer = $reinjectInstructionsPer;
 
@@ -447,8 +447,8 @@ class LarAgent
         if ($totalMessages === 0 && $this->getInstructions()) {
             $this->injectInstructions();
         } else {
-            // Reinject instructions if ReinjectInstuctionsPer is defined
-            $iip = $this->getReinjectInstuctionsPer();
+            // Reinject instructions if reinjectInstructionsPer is defined
+            $iip = $this->getReinjectInstructionsPer();
             if ($iip && $iip > 0 && $totalMessages % $iip > 0 && $totalMessages % $iip <= 5) {
                 // Hook: If any callback returns false, it will stop the process silently
                 if ($this->processBeforeReinjectingInstructions($this->chatHistory) === false) {

--- a/tests/LarAgentTest.php
+++ b/tests/LarAgentTest.php
@@ -87,7 +87,7 @@ it('can run with tools', function () {
         ->setRequired('location')
         ->setMetaData(['sent_at' => '2024-01-01'])
         ->setCallback(function ($location, $unit = 'fahrenheit') {
-            return 'The weather in ' . $location . ' is 72 degrees ' . $unit;
+            return 'The weather in '.$location.' is 72 degrees '.$unit;
         });
 
     $userMessage = Message::user('What\'s the weather like in Boston and Los Angeles? I prefer celsius');
@@ -98,7 +98,7 @@ it('can run with tools', function () {
         ->withMessage($userMessage);
 
     $agent->afterResponse(function ($agent, $message) {
-        $message->setContent($message . '. Checked at 2024-01-01');
+        $message->setContent($message.'. Checked at 2024-01-01');
     });
 
     $driver->addMockResponse('tool_calls', [
@@ -130,7 +130,7 @@ it('excludes parallel_tool_calls from config when set to null', function () {
     $agent = LarAgent::setup($driver, $chatHistory);
 
     $agent->setParallelToolCalls(null);
-    $tool = Tool::create('test_tool', 'Test tool')->setCallback(fn() => 'test');
+    $tool = Tool::create('test_tool', 'Test tool')->setCallback(fn () => 'test');
     $agent->setTools([$tool]);
 
     $reflection = new ReflectionClass($agent);


### PR DESCRIPTION
## Summary
- rename `getReinjectInstuctionsPer` and `setReinjectInstuctionsPer`
- update calls to new method names

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685c5729d6f08326b0f36296eca41453