### PR TITLE
Add additional OpenAI configuration options

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -99,6 +99,18 @@ class Agent
     /** @var ?bool */
     protected $parallelToolCalls;
 
+    /** @var int|null */
+    protected $n;
+
+    /** @var float|null */
+    protected $topP;
+
+    /** @var float|null */
+    protected $frequencyPenalty;
+
+    /** @var float|null */
+    protected $presencePenalty;
+
     /** @var string */
     protected $chatSessionId;
 
@@ -589,6 +601,34 @@ class Agent
         return $this;
     }
 
+    public function n(int $n): static
+    {
+        $this->n = $n;
+
+        return $this;
+    }
+
+    public function topP(float $topP): static
+    {
+        $this->topP = $topP;
+
+        return $this;
+    }
+
+    public function frequencyPenalty(float $penalty): static
+    {
+        $this->frequencyPenalty = $penalty;
+
+        return $this;
+    }
+
+    public function presencePenalty(float $penalty): static
+    {
+        $this->presencePenalty = $penalty;
+
+        return $this;
+    }
+
     public function withModel(string $model): static
     {
         $this->model = $model;
@@ -620,6 +660,10 @@ class Agent
             'contextWindowSize' => $this->contextWindowSize ?? null,
             'maxCompletionTokens' => $this->maxCompletionTokens ?? null,
             'temperature' => $this->temperature ?? null,
+            'n' => $this->n ?? null,
+            'topP' => $this->topP ?? null,
+            'frequencyPenalty' => $this->frequencyPenalty ?? null,
+            'presencePenalty' => $this->presencePenalty ?? null,
             'reinjectInstructionsPer' => $this->reinjectInstructionsPer ?? null,
             'parallelToolCalls' => $this->parallelToolCalls ?? null,
             'chatSessionId' => $this->chatSessionId,
@@ -693,6 +737,18 @@ class Agent
         if (! isset($this->temperature) && isset($providerData['default_temperature'])) {
             $this->temperature = $providerData['default_temperature'];
         }
+        if (! isset($this->n) && isset($providerData['default_n'])) {
+            $this->n = $providerData['default_n'];
+        }
+        if (! isset($this->topP) && isset($providerData['default_top_p'])) {
+            $this->topP = $providerData['default_top_p'];
+        }
+        if (! isset($this->frequencyPenalty) && isset($providerData['default_frequency_penalty'])) {
+            $this->frequencyPenalty = $providerData['default_frequency_penalty'];
+        }
+        if (! isset($this->presencePenalty) && isset($providerData['default_presence_penalty'])) {
+            $this->presencePenalty = $providerData['default_presence_penalty'];
+        }
         if (! isset($this->parallelToolCalls) && isset($providerData['parallel_tool_calls'])) {
             $this->parallelToolCalls = $providerData['parallel_tool_calls'];
         }
@@ -743,6 +799,18 @@ class Agent
         }
         if (property_exists($this, 'temperature')) {
             $config['temperature'] = $this->temperature;
+        }
+        if (property_exists($this, 'n')) {
+            $config['n'] = $this->n;
+        }
+        if (property_exists($this, 'topP')) {
+            $config['topP'] = $this->topP;
+        }
+        if (property_exists($this, 'frequencyPenalty')) {
+            $config['frequencyPenalty'] = $this->frequencyPenalty;
+        }
+        if (property_exists($this, 'presencePenalty')) {
+            $config['presencePenalty'] = $this->presencePenalty;
         }
         if (property_exists($this, 'parallelToolCalls')) {
             $config['parallelToolCalls'] = $this->parallelToolCalls;

--- a/src/LarAgent.php
+++ b/src/LarAgent.php
@@ -22,6 +22,14 @@ class LarAgent
 
     protected float $temperature = 1.0;
 
+    protected ?int $n = null;
+
+    protected ?float $topP = null;
+
+    protected ?float $frequencyPenalty = null;
+
+    protected ?float $presencePenalty = null;
+
     protected int $reinjectInstructionsPer = 0; // 0 Means never
 
     protected ?bool $parallelToolCalls = true;
@@ -102,6 +110,54 @@ class LarAgent
     public function setTemperature(float $temperature): self
     {
         $this->temperature = $temperature;
+
+        return $this;
+    }
+
+    public function getN(): ?int
+    {
+        return $this->n;
+    }
+
+    public function setN(?int $n): self
+    {
+        $this->n = $n;
+
+        return $this;
+    }
+
+    public function getTopP(): ?float
+    {
+        return $this->topP;
+    }
+
+    public function setTopP(?float $topP): self
+    {
+        $this->topP = $topP;
+
+        return $this;
+    }
+
+    public function getFrequencyPenalty(): ?float
+    {
+        return $this->frequencyPenalty;
+    }
+
+    public function setFrequencyPenalty(?float $frequencyPenalty): self
+    {
+        $this->frequencyPenalty = $frequencyPenalty;
+
+        return $this;
+    }
+
+    public function getPresencePenalty(): ?float
+    {
+        return $this->presencePenalty;
+    }
+
+    public function setPresencePenalty(?float $presencePenalty): self
+    {
+        $this->presencePenalty = $presencePenalty;
 
         return $this;
     }
@@ -308,6 +364,10 @@ class LarAgent
         $this->temperature = $configs['temperature'] ?? $this->temperature;
         $this->reinjectInstructionsPer = $configs['reinjectInstructionsPer'] ?? $this->reinjectInstructionsPer;
         $this->model = $configs['model'] ?? $this->model;
+        $this->n = $configs['n'] ?? $this->n;
+        $this->topP = $configs['topP'] ?? $this->topP;
+        $this->frequencyPenalty = $configs['frequencyPenalty'] ?? $this->frequencyPenalty;
+        $this->presencePenalty = $configs['presencePenalty'] ?? $this->presencePenalty;
         $this->parallelToolCalls = array_key_exists('parallelToolCalls', $configs) ? $configs['parallelToolCalls'] : $this->parallelToolCalls;
         $this->toolChoice = $configs['toolChoice'] ?? $this->toolChoice;
     }
@@ -555,6 +615,22 @@ class LarAgent
             'max_completion_tokens' => $this->getMaxCompletionTokens(),
             'temperature' => $this->getTemperature(),
         ];
+
+        if ($this->getN() !== null) {
+            $configs['n'] = $this->getN();
+        }
+
+        if ($this->getTopP() !== null) {
+            $configs['top_p'] = $this->getTopP();
+        }
+
+        if ($this->getFrequencyPenalty() !== null) {
+            $configs['frequency_penalty'] = $this->getFrequencyPenalty();
+        }
+
+        if ($this->getPresencePenalty() !== null) {
+            $configs['presence_penalty'] = $this->getPresencePenalty();
+        }
 
         if (! empty($this->tools)) {
             $PTC = $this->getParallelToolCalls();

--- a/tests/LarAgentTest.php
+++ b/tests/LarAgentTest.php
@@ -141,6 +141,29 @@ it('excludes parallel_tool_calls from config when set to null', function () {
     expect($config)->not->toHaveKey('parallel_tool_calls');
 });
 
+it('includes optional config values when set', function () {
+    $driver = new FakeLlmDriver;
+    $chatHistory = new InMemoryChatHistory('test-chat-history');
+    $agent = LarAgent::setup($driver, $chatHistory);
+
+    $agent->setN(2);
+    $agent->setTopP(0.8);
+    $agent->setFrequencyPenalty(0.1);
+    $agent->setPresencePenalty(0.2);
+
+    $reflection = new ReflectionClass($agent);
+    $buildConfig = $reflection->getMethod('buildConfig');
+    $buildConfig->setAccessible(true);
+    $config = $buildConfig->invoke($agent);
+
+    expect($config)->toMatchArray([
+        'n' => 2,
+        'top_p' => 0.8,
+        'frequency_penalty' => 0.1,
+        'presence_penalty' => 0.2,
+    ]);
+});
+
 it('uses developer role for instructions when enabled', function () {
     $driver = new FakeLlmDriver;
     $chatHistory = new InMemoryChatHistory('test-chat-history');


### PR DESCRIPTION
## Summary
- support OpenAI parameters `n`, `top_p`, `frequency_penalty` and `presence_penalty`
- propagate these options through Agent into LarAgent
- include them in LarAgent config building
- forward settings from provider defaults
- test that config values are forwarded correctly

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685d86686e108326874ccf218abbd102