### PR TITLE
Extend API request validation rules

### DIFF
--- a/src/API/Completions.php
+++ b/src/API/Completions.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LarAgent\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use LarAgent\API\completions\CompletionRequestDTO;
+
+class Completions
+{
+    public static function make(Request $request, string $agentClass): CompletionRequestDTO
+    {
+        return static::validateRequest($request);
+    }
+
+    private static function validateRequest(Request $request): CompletionRequestDTO
+    {
+        $data = $request->all();
+
+        $validator = Validator::make($data, [
+            'messages' => ['required', 'array'],
+            'messages.*' => ['array'],
+            'messages.*.role' => ['required'],
+            'messages.*.content' => ['required'],
+            'model' => ['required', 'string'],
+            'modalities' => ['nullable', 'array'],
+            'modalities.*' => ['string'],
+            'audio' => ['nullable', 'array'],
+            'audio.format' => ['required_with:audio', 'in:wav,mp3,flac,opus,pcm16'],
+            'audio.voice' => ['required_with:audio', 'in:alloy,ash,ballad,coral,echo,fable,nova,onyx,sage,shimmer'],
+            'n' => ['nullable', 'integer'],
+            'temperature' => ['nullable', 'numeric'],
+            'top_p' => ['nullable', 'numeric'],
+            'frequency_penalty' => ['nullable', 'numeric'],
+            'presence_penalty' => ['nullable', 'numeric'],
+            'max_completion_tokens' => ['nullable', 'integer'],
+            'response_format' => ['nullable', 'array'],
+            'response_format.type' => ['required_with:response_format', 'in:json_schema,json_object'],
+            'response_format.json_schema' => ['required_if:response_format.type,json_schema', 'array'],
+            'tools' => ['nullable', 'array'],
+            'tool_choice' => ['nullable'],
+            'parallel_tool_calls' => ['nullable', 'boolean'],
+        ]);
+
+        $validator->after(function ($validator) use ($data) {
+            if (isset($data['modalities']) && \is_array($data['modalities']) && \in_array('audio', $data['modalities'], true)) {
+                if (empty($data['audio']) || ! \is_array($data['audio'])) {
+                    $validator->errors()->add('audio', 'The audio field is required when requesting audio.');
+                }
+            }
+        });
+
+        $validated = $validator->validate();
+
+        return CompletionRequestDTO::fromArray($validated);
+    }
+}
+

--- a/src/API/completions/CompletionRequestDTO.php
+++ b/src/API/completions/CompletionRequestDTO.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace LarAgent\API\completions;
+
+use ArrayAccess;
+use JsonSerializable;
+
+class CompletionRequestDTO implements ArrayAccess, JsonSerializable
+{
+    public function __construct(
+        public readonly array $messages,
+        public readonly string $model,
+        public readonly ?array $modalities = null,
+        public readonly ?array $audio = null,
+        public readonly ?int $n = null,
+        public readonly ?float $temperature = null,
+        public readonly ?float $top_p = null,
+        public readonly ?float $frequency_penalty = null,
+        public readonly ?float $presence_penalty = null,
+        public readonly ?int $max_completion_tokens = null,
+        public readonly ?array $response_format = null,
+        public readonly ?array $tools = null,
+        public readonly mixed $tool_choice = null,
+        public readonly ?bool $parallel_tool_calls = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            messages: $data['messages'],
+            model: $data['model'],
+            modalities: $data['modalities'] ?? null,
+            audio: $data['audio'] ?? null,
+            n: $data['n'] ?? null,
+            temperature: $data['temperature'] ?? null,
+            top_p: $data['top_p'] ?? null,
+            frequency_penalty: $data['frequency_penalty'] ?? null,
+            presence_penalty: $data['presence_penalty'] ?? null,
+            max_completion_tokens: $data['max_completion_tokens'] ?? null,
+            response_format: $data['response_format'] ?? null,
+            tools: $data['tools'] ?? null,
+            tool_choice: $data['tool_choice'] ?? null,
+            parallel_tool_calls: $data['parallel_tool_calls'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'messages' => $this->messages,
+            'model' => $this->model,
+            'modalities' => $this->modalities,
+            'audio' => $this->audio,
+            'n' => $this->n,
+            'temperature' => $this->temperature,
+            'top_p' => $this->top_p,
+            'frequency_penalty' => $this->frequency_penalty,
+            'presence_penalty' => $this->presence_penalty,
+            'max_completion_tokens' => $this->max_completion_tokens,
+            'response_format' => $this->response_format,
+            'tools' => $this->tools,
+            'tool_choice' => $this->tool_choice,
+            'parallel_tool_calls' => $this->parallel_tool_calls,
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new \BadMethodCallException('CompletionRequestDTO is immutable.');
+    }
+
+    public function offsetUnset($offset): void
+    {
+        throw new \BadMethodCallException('CompletionRequestDTO is immutable.');
+    }
+}

--- a/tests/Api/CompletionsValidationTest.php
+++ b/tests/Api/CompletionsValidationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use LarAgent\API\Completions;
+use LarAgent\API\completions\CompletionRequestDTO;
+
+it('throws validation exception when messages field is missing', function () {
+    $request = Request::create('/api/completions', 'POST', [
+        'model' => 'gpt-4o',
+    ]);
+
+    Completions::make($request, 'TestAgent');
+})->throws(ValidationException::class);
+
+it('throws validation exception when audio is requested but not provided', function () {
+    $request = Request::create('/api/completions', 'POST', [
+        'model' => 'gpt-4o',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hi'],
+        ],
+        'modalities' => ['audio'],
+    ]);
+
+    Completions::make($request, 'TestAgent');
+})->throws(ValidationException::class);
+
+it('validates a correct request', function () {
+    $request = Request::create('/api/completions', 'POST', [
+        'model' => 'gpt-4o',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hi'],
+        ],
+        'modalities' => ['text', 'audio'],
+        'audio' => ['format' => 'mp3', 'voice' => 'nova'],
+    ]);
+
+    $result = Completions::make($request, 'TestAgent');
+
+    expect($result)->toBeInstanceOf(CompletionRequestDTO::class)
+        ->and($result['model'])->toBe('gpt-4o');
+});
+


### PR DESCRIPTION
## Summary
- expand `Completions` service validation using Laravel Validator
- return validated request via DTO
- require audio block when requesting audio
- cover valid and invalid requests in tests
- expose `CompletionRequestDTO` as array and JSON

## Testing
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_685d52392cdc8326ac0bd02be749a8c1