### PR TITLE
Handle response_format json_schema

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -632,6 +632,27 @@ class Agent
         return $this;
     }
 
+    public function maxCompletionTokens(int $tokens): static
+    {
+        $this->maxCompletionTokens = $tokens;
+
+        return $this;
+    }
+
+    public function parallelToolCalls(?bool $parallel): static
+    {
+        $this->parallelToolCalls = $parallel;
+
+        return $this;
+    }
+
+    public function responseSchema(?array $schema): static
+    {
+        $this->responseSchema = $schema;
+
+        return $this;
+    }
+
     /**
      * Set tool choice to 'auto' - model can choose to use zero, one, or multiple tools.
      * Only applies if tools are registered.

--- a/tests/Api/CompletionsBasicResponseTest.php
+++ b/tests/Api/CompletionsBasicResponseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Http\Request;
+use LarAgent\API\Completions;
+use LarAgent\Agent;
+use LarAgent\Tests\Fakes\FakeLlmDriver;
+
+class BasicDummyAgent extends Agent
+{
+    protected $model = 'gpt-4o-mini';
+    protected $history = 'in_memory';
+    protected $driver = FakeLlmDriver::class;
+
+    public function instructions()
+    {
+        return 'You are a dummy agent.';
+    }
+
+    public function prompt($message)
+    {
+        return $message;
+    }
+
+    protected function onInitialize()
+    {
+        $this->llmDriver->addMockResponse('stop', [
+            'content' => 'Hello! How can I assist you today?',
+        ]);
+    }
+}
+
+it('returns a basic completion response', function () {
+    $request = Request::create('/api/completions', 'POST', [
+        'model' => 'gpt-4o',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hi'],
+        ],
+    ]);
+
+    $response = Completions::make($request, BasicDummyAgent::class);
+
+    expect($response)->toHaveKeys(['id', 'object', 'created', 'model', 'choices'])
+        ->and($response['choices'][0]['message']['content'])
+        ->toBe('Hello! How can I assist you today?');
+});

--- a/tests/Api/CompletionsResponseSchemaTest.php
+++ b/tests/Api/CompletionsResponseSchemaTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Http\Request;
+use LarAgent\API\Completions;
+use LarAgent\Agent;
+use LarAgent\Tests\Fakes\FakeLlmDriver;
+
+class SchemaDummyAgent extends Agent
+{
+    protected $model = 'gpt-4o-mini';
+    protected $history = 'in_memory';
+    protected $driver = FakeLlmDriver::class;
+
+    public static ?array $capturedSchema = null;
+
+    public function instructions()
+    {
+        return 'You are a dummy agent.';
+    }
+
+    public function prompt($message)
+    {
+        return $message;
+    }
+
+    protected function onInitialize()
+    {
+        $this->llmDriver->addMockResponse('stop', [
+            'content' => json_encode(['foo' => 'bar']),
+        ]);
+    }
+
+    public function respond(?string $message = null): string|array
+    {
+        $response = parent::respond($message);
+        self::$capturedSchema = $this->structuredOutput();
+
+        return is_array($response) ? json_encode($response) : $response;
+    }
+}
+
+it('passes response schema from request to agent', function () {
+    SchemaDummyAgent::$capturedSchema = null;
+
+    $schema = [
+        'type' => 'object',
+        'properties' => [
+            'foo' => ['type' => 'string'],
+        ],
+    ];
+
+    $request = Request::create('/api/completions', 'POST', [
+        'model' => 'gpt-4o',
+        'messages' => [
+            ['role' => 'user', 'content' => 'hi'],
+        ],
+        'response_format' => [
+            'type' => 'json_schema',
+            'json_schema' => $schema,
+        ],
+    ]);
+
+    Completions::make($request, SchemaDummyAgent::class);
+
+    expect(SchemaDummyAgent::$capturedSchema)->toBe($schema);
+});

--- a/tests/Api/CompletionsValidationTest.php
+++ b/tests/Api/CompletionsValidationTest.php
@@ -3,14 +3,39 @@
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use LarAgent\API\Completions;
-use LarAgent\API\completions\CompletionRequestDTO;
+use LarAgent\Agent;
+use LarAgent\Tests\Fakes\FakeLlmDriver;
+
+class DummyAgent extends Agent
+{
+    protected $model = 'gpt-4o-mini';
+    protected $history = 'in_memory';
+    protected $driver = FakeLlmDriver::class;
+
+    public function instructions()
+    {
+        return 'You are a dummy agent.';
+    }
+
+    public function prompt($message)
+    {
+        return $message;
+    }
+
+    protected function onInitialize()
+    {
+        $this->llmDriver->addMockResponse('stop', [
+            'content' => 'dummy',
+        ]);
+    }
+}
 
 it('throws validation exception when messages field is missing', function () {
     $request = Request::create('/api/completions', 'POST', [
         'model' => 'gpt-4o',
     ]);
 
-    Completions::make($request, 'TestAgent');
+    Completions::make($request, DummyAgent::class);
 })->throws(ValidationException::class);
 
 it('throws validation exception when audio is requested but not provided', function () {
@@ -22,7 +47,7 @@ it('throws validation exception when audio is requested but not provided', funct
         'modalities' => ['audio'],
     ]);
 
-    Completions::make($request, 'TestAgent');
+    Completions::make($request, DummyAgent::class);
 })->throws(ValidationException::class);
 
 it('validates a correct request', function () {
@@ -35,9 +60,9 @@ it('validates a correct request', function () {
         'audio' => ['format' => 'mp3', 'voice' => 'nova'],
     ]);
 
-    $result = Completions::make($request, 'TestAgent');
+    $result = Completions::make($request, DummyAgent::class);
 
-    expect($result)->toBeInstanceOf(CompletionRequestDTO::class)
+    expect($result)->toHaveKey('choices')
         ->and($result['model'])->toBe('gpt-4o');
 });
 


### PR DESCRIPTION
## Summary
- add `responseSchema()` setter to Agent
- parse `response_format` data in Completions and configure agent
- add test covering response schema handling

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_686b4d5ef698832686361c47853649c8