### PR TITLE
Add PseudoTool tests and finalize API tool call handling

### DIFF
--- a/src/API/Completions.php
+++ b/src/API/Completions.php
@@ -25,30 +25,35 @@ class Completions
 
         $response = $instance->runAgent($agentClass);
 
-        if ($response instanceof ToolCallMessage) {
-            // @todo Return tool call
+        if (is_array($response) && isset($response['tool_calls'])) {
+            $choices = [[
+                'index' => 0,
+                'message' => $response,
+                'logprobs' => null,
+                'finish_reason' => 'tool_calls',
+            ]];
         } else {
-
             $content = (string) $response;
-
-            return [
-                'id' => $instance->agent->getChatSessionId(),
-                'object' => 'chat.completion',
-                'created' => time(),
-                'model' => $instance->agent->model(),
-                'choices' => [[
-                    'index' => 0,
-                    'message' => [
-                        'role' => 'assistant',
-                        'content' => $content,
-                        'refusal' => null,
-                        'annotations' => [],
-                    ],
-                    'logprobs' => null,
-                    'finish_reason' => 'stop',
-                ]],
-            ];
+            $choices = [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $content,
+                    'refusal' => null,
+                    'annotations' => [],
+                ],
+                'logprobs' => null,
+                'finish_reason' => 'stop',
+            ]];
         }
+
+        return [
+            'id' => $instance->agent->getChatSessionId(),
+            'object' => 'chat.completion',
+            'created' => time(),
+            'model' => $instance->agent->model(),
+            'choices' => $choices,
+        ];
 
 
     }
@@ -218,7 +223,7 @@ class Completions
                         }
                         
                         // Register the tool with the agent
-                        $this->agent->addTool($pseudoTool);
+                        $this->agent->withTool($pseudoTool);
                     }
                 }
             }

--- a/tests/Api/CompletionsToolRegistrationTest.php
+++ b/tests/Api/CompletionsToolRegistrationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Http\Request;
+use LarAgent\API\Completions;
+use LarAgent\Agent;
+use LarAgent\PseudoTool;
+use LarAgent\Tests\Fakes\FakeLlmDriver;
+
+class ToolsApiAgent extends Agent
+{
+    protected $model = 'gpt-4o-mini';
+    protected $history = 'in_memory';
+    protected $driver = FakeLlmDriver::class;
+
+    public static array $registeredTools = [];
+
+    protected function onInitialize()
+    {
+        $this->llmDriver->addMockResponse('tool_calls', [
+            'toolName' => 'api_tool',
+            'arguments' => '{}',
+        ]);
+    }
+
+    public function instructions()
+    {
+        return 'dummy';
+    }
+
+    public function prompt($message)
+    {
+        return $message;
+    }
+
+    protected function afterResponse($message)
+    {
+        self::$registeredTools = array_keys($this->llmDriver->getRegisteredTools());
+    }
+}
+
+it('registers tools from request and returns OpenAI compatible tool call message', function () {
+    ToolsApiAgent::$registeredTools = [];
+
+    $request = Request::create('/api/completions', 'POST', [
+        'model' => 'gpt-4o',
+        'messages' => [
+            ['role' => 'user', 'content' => 'hi'],
+        ],
+        'tools' => [
+            [
+                'type' => 'function',
+                'function' => [
+                    'name' => 'api_tool',
+                    'description' => 'desc',
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'foo' => ['type' => 'string'],
+                        ],
+                        'required' => ['foo'],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $response = Completions::make($request, ToolsApiAgent::class);
+
+    expect(ToolsApiAgent::$registeredTools)->toContain('api_tool')
+        ->and($response['choices'][0]['message']['tool_calls'][0]['function']['name'])->toBe('api_tool')
+        ->and($response['choices'][0]['finish_reason'])->toBe('tool_calls');
+});

--- a/tests/PseudoToolTest.php
+++ b/tests/PseudoToolTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use LarAgent\Agent;
+use LarAgent\PseudoTool;
+use LarAgent\Tests\Fakes\FakeLlmDriver;
+
+class PseudoToolAgent extends Agent
+{
+    protected $model = 'gpt-4o-mini';
+    protected $history = 'in_memory';
+    protected $driver = FakeLlmDriver::class;
+
+    public function registerTools()
+    {
+        return [
+            PseudoTool::create('pseudo_tool', 'desc')->setCallback(fn () => 'ok'),
+        ];
+    }
+
+    protected function onInitialize()
+    {
+        $this->llmDriver->addMockResponse('tool_calls', [
+            'toolName' => 'pseudo_tool',
+            'arguments' => '{}',
+        ]);
+    }
+
+    public function instructions()
+    {
+        return 'test';
+    }
+
+    public function prompt($message)
+    {
+        return $message;
+    }
+}
+
+it('returns ToolCallMessage array when pseudo tool is executed', function () {
+    $agent = PseudoToolAgent::for('test');
+    $result = $agent->respond('hi');
+
+    expect($result)->toBeArray()
+        ->and($result)->toHaveKey('tool_calls')
+        ->and($result['tool_calls'][0]['function']['name'])->toBe('pseudo_tool');
+});


### PR DESCRIPTION
## Summary
- ensure Completions API returns proper tool call structures
- register pseudo tools using `withTool`
- test agent behavior with `PseudoTool`
- test that tools sent via API are registered and returned in OpenAI format
- refactor response construction and keep metadata

## Testing
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_686be0b9f2148326900a87f170c480a8