### PR TITLE
[Feature]: Anthropic (Claude) driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "guzzlehttp/guzzle": "^7.9",
         "illuminate/contracts": "^10.0||^11.0||^12.0",
         "lucianotonet/groq-php": "^1.3",
+        "mozex/anthropic-php": "^1.1",
         "openai-php/client": "^0.14.0",
         "spatie/laravel-package-tools": "^1.16"
     },

--- a/config/laragent.php
+++ b/config/laragent.php
@@ -75,6 +75,16 @@ return [
             'default_max_completion_tokens' => 131072,
             'default_temperature' => 0.8,
         ],
+
+        'claude' => [
+            'label' => 'claude',
+            'api_key' => env('CLAUDE_API_KEY'),
+            'model' => 'claude-3-5-sonnet-latest',
+            'driver' => \LarAgent\Drivers\Anthropic\ClaudeDriver::class,
+            'default_context_window' => 200000,
+            'default_max_completion_tokens' => 8192,
+            'default_temperature' => 1,
+        ],
     ],
 
     /**

--- a/config/laragent.php
+++ b/config/laragent.php
@@ -78,7 +78,7 @@ return [
 
         'claude' => [
             'label' => 'claude',
-            'api_key' => env('CLAUDE_API_KEY'),
+            'api_key' => env('ANTHROPIC_API_KEY'),
             'model' => 'claude-3-5-sonnet-latest',
             'driver' => \LarAgent\Drivers\Anthropic\ClaudeDriver::class,
             'default_context_window' => 200000,

--- a/src/Core/Abstractions/LlmDriver.php
+++ b/src/Core/Abstractions/LlmDriver.php
@@ -117,6 +117,32 @@ abstract class LlmDriver implements LlmDriverInterface
         return $toolSchema;
     }
 
+    /**
+     * Format an array of image URLs for the API payload.
+     * This method defines the structure of images for the specific LLM API.
+     * Override this method in driver implementations to customize the image format.
+     */
+    public function formatImagesForPayload(?array $images = null): array
+    {
+        if ($images === null) {
+            throw new \Exception('No images provided to formatImagesForPayload().');
+        }
+
+        $formattedImages = [];
+
+        // Default OpenAI-compatible format
+        foreach ($images as $url) {
+            $formattedImages[] = [
+                'type' => 'image_url',
+                'image_url' => [
+                    'url' => $url,
+                ],
+            ];
+        }
+
+        return $formattedImages;
+    }
+
     abstract public function toolResultToMessage(ToolCallInterface $toolCall, mixed $result): array;
 
     abstract public function toolCallsToMessage(array $toolCalls): array;

--- a/src/Drivers/Anthropic/ClaudeDriver.php
+++ b/src/Drivers/Anthropic/ClaudeDriver.php
@@ -1,0 +1,417 @@
+<?php
+
+namespace LarAgent\Drivers\Anthropic;
+
+use Anthropic;
+use LarAgent\Core\Abstractions\LlmDriver;
+use LarAgent\Core\Contracts\LlmDriver as LlmDriverInterface;
+use LarAgent\Core\Contracts\Tool as ToolInterface;
+use LarAgent\Core\Contracts\ToolCall as ToolCallInterface;
+use LarAgent\Messages\AssistantMessage;
+use LarAgent\Messages\StreamedAssistantMessage;
+use LarAgent\Messages\ToolCallMessage;
+use LarAgent\ToolCall;
+
+class ClaudeDriver extends LlmDriver implements LlmDriverInterface
+{
+    protected mixed $client;
+
+    protected string $default_url = 'api.anthropic.com/v1';
+
+    public function __construct(array $settings = [])
+    {
+        parent::__construct($settings);
+        if ($settings['api_key']) {
+            $this->client = $this->buildClient($settings['api_key'], $settings['api_url'] ?? $this->default_url);
+        } else {
+            throw new \Exception('API key is required to use the Claude driver.');
+        }
+    }
+
+    protected function buildClient(string $apiKey, string $baseUrl): mixed
+    {
+        $client = Anthropic::factory()
+            ->withApiKey($apiKey)
+            ->withBaseUri($baseUrl)
+            ->withHttpHeader('anthropic-version', '2023-06-01')
+            ->withHttpClient($httpClient = new \GuzzleHttp\Client([]))
+            ->make();
+
+        return $client;
+    }
+
+    public function sendMessage(array $messages, array $options = []): AssistantMessage
+    {
+        if (empty($this->client)) {
+            throw new \Exception('API key is required to use the Claude driver.');
+        }
+
+        $payload = $this->preparePayload($messages, $options);
+
+        $response = $this->client->messages()->create($payload);
+        $this->lastResponse = $response;
+
+        $stopReason = $response->stop_reason;
+        $metaData = ['usage' => $response->usage->toArray()];
+
+        if ($stopReason === 'tool_use') {
+            $toolCalls = [];
+
+            foreach ($response->content as $item) {
+                if (($item->type ?? null) === 'tool_use') {
+                    $toolCalls[] = new ToolCall(
+                        $item->id ?? '',
+                        $item->name ?? '',
+                        json_encode($item->input ?? [])
+                    );
+                }
+            }
+
+            $message = $this->toolCallsToMessage($toolCalls);
+
+            $toolCallMessage = new ToolCallMessage(
+                toolCalls: $toolCalls,
+                message: $message,
+                metadata: $metaData
+            );
+
+            return $toolCallMessage;
+        }
+
+        if ($stopReason === 'end_turn') {
+            $content = $response->content[0]->text;
+
+            $assistantMessage = new AssistantMessage($content, $metaData);
+
+            return $assistantMessage;
+        }
+
+        throw new \Exception('Unexpected stop reason: '.$stopReason);
+    }
+
+    public function sendMessageStreamed(array $messages, array $options = [], ?callable $callback = null): \Generator
+    {
+        if (empty($this->client)) {
+            throw new \Exception('API key is required to use the Claude driver.');
+        }
+
+        $payload = $this->preparePayload($messages, $options);
+        $payload['stream'] = true;
+
+        $response = $this->client->messages()->createStreamed($payload);
+        $streamedMessage = new StreamedAssistantMessage;
+
+        $toolCalls = [];
+        $pendingToolInputs = []; // id => partial JSON
+        $pendingToolNames = []; // id => tool name
+        $currentToolBlockIds = []; // index => tool use id
+
+        $firstUsage = null; // first snapshot
+        $finalUsage = null; // final snapshot
+        $usageTimeline = []; // list of snapshots for each message type
+
+        foreach ($response as $chunk) {
+            $this->lastResponse = $chunk;
+
+            $type = $chunk->type ?? null;
+
+            // Message start
+            if ($type === 'message_start') {
+                $messageStartUsage = $chunk->usage?->toArray();
+                if ($messageStartUsage) {
+                    // create earliest usage
+                    $firstUsage = $firstUsage ?? $messageStartUsage;
+                    // create earliest usage timeline
+                    $usageTimeline[] = ['event' => 'message_start', 'usage' => $messageStartUsage];
+
+                    $streamedMessage->setUsage($messageStartUsage);
+                }
+
+                continue;
+            }
+
+            // Tool start
+            if ($type === 'content_block_start') {
+                $block = $chunk->content_block_start ?? $chunk->content_block ?? null;
+                if (($block->type ?? '') === 'tool_use') {
+                    $id = $block->id ?? 'tool_call_'.uniqid();
+                    $pendingToolNames[$id] = $block->name ?? '';
+                    $pendingToolInputs[$id] = '';
+                    $currentToolBlockIds[$chunk->index] = $id;
+                }
+
+                continue;
+            }
+
+            // Text or tool input delta
+            if ($type === 'content_block_delta') {
+                $delta = $chunk->delta ?? null;
+                $deltaType = $delta->type ?? '';
+
+                if ($deltaType === 'text_delta') {
+                    $text = $delta->text ?? '';
+                    if ($text !== '') {
+                        $streamedMessage->appendContent($text);
+
+                        if ($callback) {
+                            $callback($streamedMessage);
+                        }
+                        yield $streamedMessage;
+                    }
+                } elseif ($deltaType === 'input_json_delta') {
+                    $id = $chunk->content_block->id ?? ($currentToolBlockIds[$chunk->index] ?? null);
+
+                    if ($id !== null) {
+                        // Append partial_json
+                        $pendingToolInputs[$id] = ($pendingToolInputs[$id] ?? '').($delta->partial_json ?? '');
+                    }
+                }
+
+                continue;
+            }
+
+            // Tool stop and finalize
+            if ($type === 'content_block_stop') {
+                $block = $chunk->content_block_stop ?? $chunk->content_block ?? null;
+                if (($block->type ?? '') === 'tool_use') {
+                    $id = $block->id ?? ($currentToolBlockIds[$chunk->index] ?? null);
+                    if ($id !== null) {
+                        $name = $pendingToolNames[$id] ?? '';
+                        $args = $pendingToolInputs[$id] ?? '{}';
+
+                        $toolCalls[] = new ToolCall($id, $name, $args);
+
+                        // unset pending maps
+                        unset($pendingToolNames[$id], $pendingToolInputs[$id]);
+
+                        // clear the index map for this block
+                        if (isset($chunk->index)) {
+                            unset($currentToolBlockIds[$chunk->index]);
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            // End of message deltas
+            if ($type === 'message_delta') {
+                $stopReason = $chunk->delta->stop_reason ?? null;
+
+                if (isset($chunk->usage)) {
+                    $messageDeltaUsage = $chunk->usage?->toArray();
+                    if ($messageDeltaUsage) {
+                        $usageTimeline[] = ['event' => 'message_delta', 'usage' => $messageDeltaUsage];
+                    }
+                }
+
+                if ($stopReason === 'tool_use') {
+                    // Tool finalize
+                    if (! empty($pendingToolInputs)) {
+                        foreach ($pendingToolInputs as $id => $args) {
+                            $name = $pendingToolNames[$id] ?? '';
+                            $args = $args ?? '{}';
+                            $toolCalls[] = new ToolCall($id, $name, $args);
+                        }
+                        $pendingToolInputs = [];
+                        $pendingToolNames = [];
+                    }
+
+                    $finalUsage = $chunk->usage?->toArray() ?? $finalUsage;
+                    $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
+
+                    $message = $this->toolCallsToMessage($toolCalls);
+                    $toolCallMessage = new ToolCallMessage(
+                        toolCalls: $toolCalls,
+                        message: $message,
+                        metadata: [
+                            'usage' => $merged,
+                            'usage_timeline' => $usageTimeline,
+                        ]
+                    );
+
+                    if ($callback) {
+                        $callback($toolCallMessage);
+                    }
+                    yield $toolCallMessage;
+
+                    return;
+                }
+
+                if ($stopReason === 'end_turn') {
+                    $finalUsage = $chunk->usage?->toArray() ?? $finalUsage;
+                    // set the final usage on the streamed text message
+                    $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
+                    $streamedMessage->setUsage($merged);
+                    break;
+                }
+            }
+
+            if ($type === 'message_stop') {
+                break;
+            }
+        }
+
+        // Final flush for text
+        if ($streamedMessage->getContent()) {
+            $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
+
+            $meta = $streamedMessage->toArrayWithMeta();
+            $meta['metadata']['usage'] = $merged;
+            $meta['metadata']['usage_timeline'] = $usageTimeline;
+
+            yield $streamedMessage;
+        }
+    }
+
+    protected function preparePayload(array $messages, array $options = []): array
+    {
+        if ($this->structuredOutputEnabled()) {
+            throw new \Exception('Anthropic/Claude driver does not support structured output through JSON schema.');
+        }
+
+        $payload = [];
+
+        if (empty($options['model'])) {
+            $options['model'] = $this->settings['model'] ?? 'claude-3-5-sonnet-latest';
+        }
+
+        $payload['model'] = $options['model'];
+
+        $this->setConfig($options);
+
+        $systemPrompt = null;
+        $chatMessages = [];
+
+        foreach ($messages as $message) {
+            if ($message['role'] === 'system') {
+                $systemPrompt = $message['content'];
+            } else {
+                $messageContent = [];
+
+                foreach ($message['content'] as $item) {
+                    // Format each image URL into Claude's expected format
+                    if (isset($item['type'], $item['image_url']['url']) && $item['type'] === 'image_url') {
+                        $messageContent[] = $this->formatImagesForPayload([$item['image_url']['url']])[0];
+                    } else {
+                        $messageContent[] = $item;
+                    }
+                }
+
+                $chatMessages[] = [
+                    'role' => $message['role'],
+                    'content' => $messageContent,
+                ];
+
+            }
+        }
+
+        if ($systemPrompt) {
+            $payload['system'] = $systemPrompt;
+        }
+
+        $payload['messages'] = $chatMessages;
+
+        $payload['max_tokens'] = $options['max_completion_tokens'] ?? $this->settings['max_completion_tokens'] ?? 1024;
+
+        if (isset($options['temperature'])) {
+            $payload['temperature'] = $options['temperature'];
+        }
+
+        if (! empty($this->tools)) {
+            foreach ($this->getRegisteredTools() as $tool) {
+                $payload['tools'][] = $this->formatToolForPayload($tool);
+            }
+        }
+
+        return $payload;
+    }
+
+    public function formatToolForPayload(ToolInterface $tool): array
+    {
+        return [
+            'name' => $tool->getName(),
+            'description' => $tool->getDescription(),
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => $tool->getProperties(),
+                'required' => $tool->getRequired(),
+            ],
+        ];
+    }
+
+    public function toolCallsToMessage(array $toolCalls): array
+    {
+        $content = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $content[] = [
+                'type' => 'tool_use',
+                'id' => $toolCall->getId(),
+                'name' => $toolCall->getToolName(),
+                'input' => json_decode($toolCall->getArguments(), true),
+            ];
+        }
+
+        return [
+            'role' => 'assistant',
+            'content' => $content,
+        ];
+    }
+
+    public function toolResultToMessage(ToolCallInterface $toolCall, mixed $result): array
+    {
+        return [
+            'role' => 'user',
+            'content' => [
+                [
+                    'type' => 'tool_result',
+                    'tool_use_id' => $toolCall->getId(),
+                    'content' => is_string($result) ? $result : json_encode($result),
+                ],
+            ],
+        ];
+    }
+
+    public function formatImagesForPayload(?array $images = null): array
+    {
+        $formattedImages = [];
+
+        foreach ($images as $url) {
+            $formattedImages[] = [
+                'type' => 'image',
+                'source' => [
+                    'type' => 'url',
+                    'url' => $url,
+                ],
+            ];
+        }
+
+        return $formattedImages;
+    }
+
+    private function mergeUsageSnapshots(?array $first, ?array $final): array
+    {
+        $first = $first ?? [];
+        $final = $final ?? [];
+
+        // Input tokens: the first snapshot already represents the full prompt
+        // (final often omits it or repeats same value). Prefer first.
+        $input = $first['input_tokens'] ?? $final['input_tokens'] ?? null;
+
+        // Output tokens: final is the total at the end, not a delta.
+        // Prefer final, else fall back to first.
+        $output = $final['output_tokens'] ?? $first['output_tokens'] ?? null;
+
+        // Sanity: if both exist and "first > final", pick the max to avoid weird regressions.
+        if (isset($first['output_tokens'], $final['output_tokens'])) {
+            $output = max($first['output_tokens'], $final['output_tokens']);
+        }
+
+        return [
+            'input_tokens' => $input,
+            'output_tokens' => $output,
+            'total_tokens' => ($input ?? 0) + ($output ?? 0),
+        ];
+    }
+}

--- a/testsManual/.gitignore
+++ b/testsManual/.gitignore
@@ -1,3 +1,4 @@
 groq-api-key.php
 openai-api-key.php
 gemini-api-key.php
+anthropic-api-key.php

--- a/testsManual/ClaudeDriverTest.php
+++ b/testsManual/ClaudeDriverTest.php
@@ -1,0 +1,403 @@
+<?php
+
+use LarAgent\Agent;
+use LarAgent\Drivers\Anthropic\ClaudeDriver;
+use LarAgent\Tests\TestCase;
+use LarAgent\Tool;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+
+    $yourApiKey = include 'anthropic-api-key.php';
+
+    config()->set('laragent.fallback_provider', 'claude');
+
+    config()->set('laragent.providers.claude', [
+        'label' => 'claude',
+        'model' => 'claude-3-5-sonnet-latest',
+        'api_key' => $yourApiKey,
+        'driver' => ClaudeDriver::class,
+        'default_context_window' => 200000,
+        'default_max_completion_tokens' => 8192,
+        'default_temperature' => 0.9,
+    ]);
+});
+
+// WeatherTool class
+class WeatherTool extends Tool
+{
+    protected string $name = 'get_current_weather';
+
+    protected string $description = 'Get the current weather in a given country.Respond using the word "celsius" or "fahrenheit" instead of symbols like °C or °F.';
+
+    protected array $properties = [
+        'location' => [
+            'type' => 'string',
+            'description' => 'The country, e.g Malaysia, Singapore',
+        ],
+        'unit' => [
+            'type' => 'string',
+            'description' => 'The unit of temperature',
+            'enum' => ['celsius', 'fahrenheit'],
+        ],
+    ];
+
+    protected array $required = ['location'];
+
+    protected array $metaData = ['sent_at' => '2025-07-01'];
+
+    public function execute(array $input): mixed
+    {
+        $location = $input['location'] ?? 'unknown location';
+        $unit = $input['unit'] ?? 'celsius';
+
+        if (strtolower($location) == 'malaysia') {
+            $temperature = '32';
+        } else {
+            $temperature = '33';
+        }
+
+        return [
+            'location' => $location,
+            'unit' => $unit,
+            'temperature' => $temperature,
+        ];
+    }
+}
+
+// TemperatureTool for parallelToolCalls test
+class TemperatureTool extends Tool
+{
+    protected string $name = 'get_temperature';
+
+    protected string $description = 'Get the temperature for a given city';
+
+    protected array $properties = [
+        'location' => [
+            'type' => 'string',
+            'description' => 'The name of the city',
+        ],
+    ];
+
+    protected array $required = ['location'];
+
+    protected array $metaData = ['sent_at' => '2025-07-01'];
+
+    public function execute(array $input): mixed
+    {
+        $temperatures = [
+            'Kuala Lumpur' => '32 celsius',
+            'Tokyo' => '26 celsius',
+        ];
+
+        return $temperatures[$input['location']] ?? 'Temperature data not available';
+    }
+}
+
+// WeatherConditionTool for parallelToolCalls test
+class WeatherConditionTool extends Tool
+{
+    protected string $name = 'get_weather_condition';
+
+    protected string $description = 'Get the weather condition for a given city';
+
+    protected array $properties = [
+        'location' => [
+            'type' => 'string',
+            'description' => 'The name of the city',
+        ],
+    ];
+
+    protected array $required = ['location'];
+
+    protected array $metaData = ['sent_at' => '2025-07-01'];
+
+    public function execute(array $input): mixed
+    {
+        $conditions = [
+            'Kuala Lumpur' => 'Sunny',
+            'Tokyo' => 'Rainy',
+        ];
+
+        return $conditions[$input['location']] ?? 'Weather condition data not available';
+    }
+}
+
+// Test Agent
+class ClaudeTestAgent extends Agent
+{
+    protected $provider = 'claude';
+
+    protected $model = 'claude-3-5-sonnet-latest';
+
+    protected $history = 'in_memory';
+
+    public function instructions()
+    {
+        return 'You are a helpful assistant';
+    }
+
+    public function prompt($message)
+    {
+        return $message.' Please respond and follow instruction appropriately.';
+    }
+}
+
+// Test Agent using WeatherTool
+class ToolTestAgent extends ClaudeTestAgent
+{
+    public $saveToolResult = null;
+
+    public function instructions()
+    {
+        return <<<'EOT'
+        You are a weather assistant. Always use the available tools to retrieve weather data.
+        For any user request, do the following:
+        - Call the tool to get temperature and weather for the location.
+        - Respond only using the tool result, especially the summary field.
+        - Do not include any extra notes, disclaimers, or general explanations.
+        EOT;
+    }
+
+    public function prompt($message)
+    {
+        return 'Use the tools to complete this request. '.$message;
+
+    }
+
+    public function registerTools()
+    {
+        return [
+            new WeatherTool,
+        ];
+    }
+
+    protected function afterToolExecution($tool, &$result)
+    {
+        $this->saveToolResult = $result;
+    }
+}
+
+// Test Agent using parallel tools
+class ParallelToolTestAgent extends ClaudeTestAgent
+{
+    public $toolCalls = [];
+
+    public function instructions()
+    {
+        return <<<'EOT'
+        You are a weather assistant. Always use the available tools to fetch temperature and weather condition.
+
+        Your task:
+        - Call tools to get temperature and condition for each city
+        - Then reply with exactly one sentence per city in the format:
+        "{City} is currently {condition} with a temperature of {temperature}."
+
+        Do not include disclaimers, apologies, or additional commentary.
+        EOT;
+    }
+
+    public function prompt($message)
+    {
+        return 'Use the tools to complete this request. '.$message;
+    }
+
+    public function registerTools()
+    {
+        return [
+            new TemperatureTool,
+            new WeatherConditionTool,
+        ];
+    }
+
+    protected function afterToolExecution($tool, &$result)
+    {
+        $this->toolCalls[] = [
+            'tool' => $tool->getName(),
+            'result' => $result,
+        ];
+    }
+}
+
+// To test error is thrown when structuredOutput is used with the Anthropic/Claude driver.
+class StructuredOutputClaudeTestAgent extends ClaudeTestAgent
+{
+    protected $maxCompletionTokens = 8192;
+
+    public function instructions()
+    {
+        return 'Extract structured product data (name and price) from the text.';
+    }
+
+    public function prompt($message)
+    {
+        return "Here is a product description: {$message}";
+    }
+
+    // Define the schema for structured output tests
+    protected $responseSchema = [
+        'name' => 'get_price',
+        'schema' => [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'description' => 'Name of the product'],
+                'price' => ['type' => 'string', 'description' => 'Price of the product with currency'],
+            ],
+            'required' => ['name', 'price'],
+        ],
+    ];
+
+    // Override to return the schema
+    public function structuredOutput()
+    {
+        return $this->responseSchema;
+    }
+}
+
+it('can send a message using respond', function () {
+    $agent = ClaudeTestAgent::for('send_test');
+
+    $response = $agent->respond('Say anything and end your response with "This is a test response"');
+
+    expect($response)->toContain('This is a test response');
+});
+
+/**
+ * This test ensures an error is thrown when structuredOutput is used with the Anthropic/Claude driver.
+ * Claude does not support JSON schema-based structured output. Instead, Anthropic recommends using prompt-based methods to enforce JSON consistency.
+ * Reference: https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/increase-consistency
+ */
+it('throws exception when structured output is enabled for Claude', function () {
+    $agent = StructuredOutputClaudeTestAgent::for('structured_test');
+
+    expect(fn () => $agent->respond('The Apple Watch is priced around $799.'))
+        ->toThrow(\Exception::class, 'Anthropic/Claude driver does not support structured output through JSON schema.');
+});
+
+it('can stream responses using respondStreamed', function () {
+    $agent = ClaudeTestAgent::for('response_streamed_test');
+
+    // Get the stream
+    $stream = $agent->respondStreamed('Say anything and end your response with "This is a streaming response"');
+
+    // Verify the stream is a Generator
+    expect($stream)->toBeInstanceOf(\Generator::class);
+
+    // Collect all messages from the stream
+    $messages = [];
+    foreach ($stream as $message) {
+        $messages[] = $message;
+    }
+
+    // Verify we received messages
+    expect($messages)->not->toBeEmpty();
+
+    // Check the content of the last message
+    $lastMessage = end($messages);
+    expect($lastMessage->getContent() ?? $lastMessage)->toContain('This is a streaming response');
+});
+
+it('can stream responses using streamResponse in plain format', function () {
+    $agent = ClaudeTestAgent::for('stream_response_test');
+
+    // Get the response
+    $response = $agent->streamResponse('Say anything and end your response with "This is a streaming response', 'plain');
+
+    // Verify it's a StreamedResponse
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    // Check headers directly from the response object
+    expect($response->headers->get('Content-Type'))->toBe('text/plain');
+
+    // Capture the streamed output
+    ob_start();
+    ob_start();
+    $response->sendContent();
+    ob_get_clean(); // inner buffer flushed by response
+    $output = ob_get_clean();
+
+    // Ensure the body contains the expected text
+    expect($output)->toContain('This is a streaming response');
+});
+
+it('can stream with tools use', function () {
+    $agent = ToolTestAgent::for('stream_response_test');
+
+    // Get the response
+    $response = $agent->streamResponse('What is the current weather in Malaysia in celsius?', 'plain');
+
+    // Verify it's a StreamedResponse
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    // Check headers directly from the response object
+    expect($response->headers->get('Content-Type'))->toBe('text/plain');
+
+    // Capture the streamed output
+    ob_start();
+    ob_start();
+    $response->sendContent();
+    ob_get_clean(); // inner buffer flushed by response
+    $output = ob_get_clean();
+
+    // Ensure the body contains the expected text
+    expect(strtolower($output))->toContain('malaysia')->toContain('celsius');
+});
+
+it('can stream with multiple tools use', function () {
+    $agent = ParallelToolTestAgent::for('parallel_stream_response_test');
+
+    // Get the response
+    $response = $agent->streamResponse("What's the weather and temperature like in Kuala Lumpur and Tokyo?", 'plain');
+
+    // Verify it's a StreamedResponse
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    // Check headers directly from the response object
+    expect($response->headers->get('Content-Type'))->toBe('text/plain');
+
+    // Capture the streamed output
+    ob_start();
+    ob_start();
+    $response->sendContent();
+    ob_get_clean(); // inner buffer flushed by response
+    $output = ob_get_clean();
+
+    // Ensure the body contains the expected text
+    expect(strtolower($output))->toContain('kuala lumpur')->toContain('tokyo')->toContain('celsius');
+});
+
+it('can use tool', function () {
+    $agent = ToolTestAgent::for('tool_test');
+
+    $response = $agent->respond('What is the current weather in Malaysia in celsius?');
+
+    expect(strtolower($response))->toContain('malaysia')->toContain('celsius');
+});
+
+it('can use multiple tools in parallel', function () {
+    $agent = ParallelToolTestAgent::for('parallel_weather_test');
+
+    $response = $agent->respond("What's the weather and temperature like in Kuala Lumpur and Tokyo?");
+
+    // There should be 4 tool calls: 2 cities x 2 tools
+    expect($agent->toolCalls)->toHaveCount(4);
+
+    $toolNames = array_column($agent->toolCalls, 'tool');
+    expect($toolNames)->toContain('get_temperature')
+        ->toContain('get_weather_condition');
+
+    expect(strtolower($response))->toContain('kuala lumpur')->toContain('tokyo')->toContain('celsius');
+});
+
+it('can use vision model with image url', function () {
+    $agent = ClaudeTestAgent::for('vision_test');
+    $agent->withImages([
+        'https://blog.laragent.ai/content/images/2025/05/light.png',
+    ]);
+
+    $response = $agent->respond('What is the text in this image?');
+
+    expect($response)->toContain('LarAGENT');
+});


### PR DESCRIPTION
This PR introduces a new `ClaudeDriver` that integrates Anthropic's Claude models into LarAgent.It supports standard message responses, tool usage, and streaming.

### Key Features

- Supports Claude 3.5 and other Anthropic models.
- Full compatibility with LarAgent's tool calling mechanism.
- This driver currently throws exception when `structuredOutput()` is enabled, as Claude does not currently support JSON Schema–style structured outputs.
- Adds a default formatImagesForPayload() method in LlmDriver for converting image URLs into API-ready format, with option for drivers to override.

### Manual Test

All manual tests are passing:

```bash
PASS  TestsManual\ClaudeDriverTest
✓ it throws exception when structured output is enabled for Claude
✓ it can stream responses using streamResponse in plain format
✓ it can use vision model with image url
✓ it can stream with multiple tools use
✓ it can send a message using respond
✓ it can stream with tools use
✓ it can use multiple tools in parallel
✓ it can use tool 
✓ it can stream responses using respondStreamed 
```

### References

- Anthropic Docs Overview
https://docs.anthropic.com/en/docs/intro

### Dependencies

- Uses [`mozex/anthropic-php`](https://github.com/mozex/anthropic-php) for API requests.

### Notes for Maintainers

- **Structured outputs:** Anthropic’s API does not currently support JSON Schema–style structured outputs.  
  Their documentation instead recommends prompt-based techniques to improve JSON consistency.  
  Reference: https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/increase-consistency

- **Vision model image handling:** Claude’s vision API expects a different image payload format than LarAgent’s default.  
  Reference: https://docs.anthropic.com/en/docs/build-with-claude/vision#can-claude-read-image-urls
