### PR TITLE
fix groq driver and improvements for claude driver

### DIFF
--- a/config/laragent.php
+++ b/config/laragent.php
@@ -55,7 +55,6 @@ return [
         'groq' => [
             'label' => 'groq',
             'api_key' => env('GROQ_API_KEY'),
-            'api_url' => 'https://api.groq.com/openai/v1',
             'driver' => \LarAgent\Drivers\Groq\GroqDriver::class,
             'default_context_window' => 131072,
             'default_max_completion_tokens' => 131072,

--- a/src/Drivers/Anthropic/ClaudeDriver.php
+++ b/src/Drivers/Anthropic/ClaudeDriver.php
@@ -243,6 +243,7 @@ class ClaudeDriver extends LlmDriver implements LlmDriverInterface
                     // set the final usage on the streamed text message
                     $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
                     $streamedMessage->setUsage($merged);
+                    $streamedMessage->setComplete(true);
                     break;
                 }
             }
@@ -252,16 +253,19 @@ class ClaudeDriver extends LlmDriver implements LlmDriverInterface
             }
         }
 
-        // Final flush for text
-        if ($streamedMessage->getContent()) {
-            $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
+        // Finalize the stream: attach merged usage, trigger callback, 
+        // mark the message as complete, and yield the final message.
+        $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
+        $streamedMessage->setUsage($merged);
 
-            $meta = $streamedMessage->toArrayWithMeta();
-            $meta['metadata']['usage'] = $merged;
-            $meta['metadata']['usage_timeline'] = $usageTimeline;
-
-            yield $streamedMessage;
+        if ($callback) {
+            $callback($streamedMessage);
         }
+
+        $streamedMessage->setComplete(true);
+
+        yield $streamedMessage;
+
     }
 
     protected function preparePayload(array $messages, array $options = []): array

--- a/src/Drivers/Anthropic/ClaudeDriver.php
+++ b/src/Drivers/Anthropic/ClaudeDriver.php
@@ -243,7 +243,6 @@ class ClaudeDriver extends LlmDriver implements LlmDriverInterface
                     // set the final usage on the streamed text message
                     $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
                     $streamedMessage->setUsage($merged);
-                    $streamedMessage->setComplete(true);
                     break;
                 }
             }
@@ -253,7 +252,7 @@ class ClaudeDriver extends LlmDriver implements LlmDriverInterface
             }
         }
 
-        // Finalize the stream: attach merged usage, trigger callback, 
+        // Finalize the stream: attach merged usage, trigger callback,
         // mark the message as complete, and yield the final message.
         $merged = $this->mergeUsageSnapshots($firstUsage, $finalUsage);
         $streamedMessage->setUsage($merged);

--- a/src/Drivers/Groq/GroqDriver.php
+++ b/src/Drivers/Groq/GroqDriver.php
@@ -198,8 +198,14 @@ class GroqDriver extends LlmDriver implements LlmDriverInterface
         }
 
         // No explicit finish_reason — finalize stream message
+        if ($lastUsage) {
+            $stream->setUsage($lastUsage);
+        }
         $stream->setComplete(true);
 
+        if ($callback) {
+            $callback($stream);
+        }
         yield $stream;
     }
 

--- a/testsManual/GroqDriverTest.php
+++ b/testsManual/GroqDriverTest.php
@@ -20,11 +20,11 @@ beforeEach(function () {
 
     config()->set('laragent.providers.groq', [
         'label' => 'groq',
-        'model' => 'llama-3.1-8b-instant',
+        'model' => 'openai/gpt-oss-120b',
         'driver' => GroqDriver::class,
         'api_key' => $yourApiKey,
         'default_context_window' => 131072,
-        'default_max_completion_tokens' => 131072,
+        'default_max_completion_tokens' => 65536,
         'default_temperature' => 1,
     ]);
 });
@@ -130,7 +130,7 @@ class GroqTestAgent extends Agent
 {
     protected $provider = 'groq';
 
-    protected $model = 'llama-3.1-8b-instant';
+    protected $model = 'openai/gpt-oss-120b';
 
     protected $history = 'in_memory';
 
@@ -265,7 +265,7 @@ class SimpleStructuredOutputGroqTestAgent extends GroqTestAgent
 {
     public function instructions()
     {
-        return 'Extract product data (name of the product and price of the product with currency symbol) from the user message. Provide your output in json format with only the keys: name and product.';
+        return 'Extract product data (name of the product and price of the product with currency symbol) from the user message. Provide your output in json format with only the keys: name and price.';
     }
 
     public function prompt($message)


### PR DESCRIPTION
## Groq
1. **api_url** — previously custom `api_url` config didn’t work, now respected.  
2. **sendMessageStreamed** — fixed tool call handling during streaming. Improved streaming usage for more reliable output.
3. **test file** — add test case for tool use in streaming. Fixed mismatch array key.

## Claude
1. **sendMessageStreamed** — improved streaming usage for more reliable output.  