### PR TITLE
Openrouter driver

### DIFF
--- a/config/laragent.php
+++ b/config/laragent.php
@@ -61,6 +61,26 @@ return [
             'default_temperature' => 1,
         ],
 
+        'claude' => [
+            'label' => 'claude',
+            'api_key' => env('ANTHROPIC_API_KEY'),
+            'model' => 'claude-3-7-sonnet-latest',
+            'driver' => \LarAgent\Drivers\Anthropic\ClaudeDriver::class,
+            'default_context_window' => 200000,
+            'default_max_completion_tokens' => 8192,
+            'default_temperature' => 1,
+        ],
+
+        'openrouter' => [
+            'label' => 'openrouter',
+            'api_key' => env('OPENROUTER_API_KEY'),
+            'model' => 'openai/gpt-oss-20b:free',
+            'driver' => \LarAgent\Drivers\OpenAi\OpenRouter::class,
+            'default_context_window' => 200000,
+            'default_max_completion_tokens' => 8192,
+            'default_temperature' => 1,
+        ],
+
         /**
          * Assumes you have ollama server running with default settings
          * Where URL is http://localhost:11434/v1 and no api_key
@@ -73,16 +93,6 @@ return [
             'default_context_window' => 131072,
             'default_max_completion_tokens' => 131072,
             'default_temperature' => 0.8,
-        ],
-
-        'claude' => [
-            'label' => 'claude',
-            'api_key' => env('ANTHROPIC_API_KEY'),
-            'model' => 'claude-3-7-sonnet-latest',
-            'driver' => \LarAgent\Drivers\Anthropic\ClaudeDriver::class,
-            'default_context_window' => 200000,
-            'default_max_completion_tokens' => 8192,
-            'default_temperature' => 1,
         ],
     ],
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -159,6 +159,7 @@ class Agent
     public function __construct($key)
     {
         $this->setupProviderData();
+        $this->setName();
         $this->setChatSessionId($key);
         $this->setupChatHistory();
         $this->onInitialize();
@@ -502,6 +503,16 @@ class Agent
     }
 
     /**
+     * Get the name of the agent
+     *
+     * @return string The agent's name
+     */
+    public function name()
+    {
+        return $this->name;
+    }
+
+    /**
      * Create a new chat history instance
      *
      * @param  string  $sessionId  The session ID for the chat history
@@ -637,7 +648,7 @@ class Agent
     public function getChatKeys(): array
     {
         $keys = $this->chatHistory->loadKeysFromMemory();
-        $agentClass = class_basename(static::class);
+        $agentClass = $this->name();
 
         return array_filter($keys, function ($key) use ($agentClass) {
             return str_starts_with($key, $agentClass . '_');
@@ -917,6 +928,13 @@ class Agent
 
     // Helper methods
 
+    protected function setName(): static
+    {
+        $this->name = class_basename(static::class);
+
+        return $this;
+    }
+
     protected function setChatSessionId(string $id): static
     {
         $this->chatKey = $id;
@@ -930,7 +948,7 @@ class Agent
         if ($this->keyIncludesModelName()) {
             return sprintf(
                 '%s_%s_%s',
-                class_basename(static::class),
+                $this->name(),
                 $this->model(),
                 $this->getChatKey()
             );
@@ -938,7 +956,7 @@ class Agent
 
         return sprintf(
             '%s_%s',
-            class_basename(static::class),
+            $this->name(),
             $this->getChatKey()
         );
     }
@@ -1157,7 +1175,7 @@ class Agent
         }
 
         $message->addMeta([
-            'agent' => basename(static::class),
+            'agent' => $this->name(),
             'model' => $this->model(),
         ]);
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -92,6 +92,14 @@ class Agent
     protected $saveChatKeys;
 
     /**
+     * Name of the agent
+     * Basename of the class by default
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
      * Chat key associated with this agent
      *
      * @var string

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -392,14 +392,14 @@ class Agent
                             'delta' => $delta,
                             'content' => $chunk->getContent(),
                             'complete' => $chunk->isComplete(),
-                        ]) . "\n";
+                        ])."\n";
                     } elseif ($format === 'sse') {
                         echo "event: chunk\n";
-                        echo 'data: ' . json_encode([
+                        echo 'data: '.json_encode([
                             'delta' => $delta,
                             'content' => $chunk->getContent(),
                             'complete' => $chunk->isComplete(),
-                        ]) . "\n\n";
+                        ])."\n\n";
                     }
 
                     if (ob_get_level() > 0) {
@@ -416,15 +416,15 @@ class Agent
                             'delta' => '',
                             'content' => $chunk,
                             'complete' => true,
-                        ]) . "\n";
+                        ])."\n";
                     } elseif ($format === 'sse') {
                         echo "event: structured\n";
-                        echo 'data: ' . json_encode([
+                        echo 'data: '.json_encode([
                             'type' => 'structured',
                             'delta' => '',
                             'content' => $chunk,
                             'complete' => true,
-                        ]) . "\n\n";
+                        ])."\n\n";
                     }
 
                     ob_flush();
@@ -440,7 +440,7 @@ class Agent
             // Signal completion
             if ($format === 'sse') {
                 echo "event: complete\n";
-                echo 'data: ' . json_encode(['content' => $accumulated]) . "\n\n";
+                echo 'data: '.json_encode(['content' => $accumulated])."\n\n";
                 ob_flush();
                 flush();
             }
@@ -659,7 +659,7 @@ class Agent
         $agentClass = $this->name();
 
         return array_filter($keys, function ($key) use ($agentClass) {
-            return str_starts_with($key, $agentClass . '_');
+            return str_starts_with($key, $agentClass.'_');
         });
     }
 
@@ -916,13 +916,13 @@ class Agent
             'reinjectInstructionsPer' => $this->reinjectInstructionsPer ?? null,
             'parallelToolCalls' => $this->parallelToolCalls ?? null,
             'chatSessionId' => $this->chatSessionId,
-        ], fn($value) => ! is_null($value));
+        ], fn ($value) => ! is_null($value));
 
         return new AgentDTO(
             provider: $this->provider,
             providerName: $this->providerName,
             message: $this->message,
-            tools: array_map(fn(ToolInterface $tool) => $tool->getName(), $this->getTools()),
+            tools: array_map(fn (ToolInterface $tool) => $tool->getName(), $this->getTools()),
             instructions: $this->instructions,
             responseSchema: $this->responseSchema,
             configuration: [
@@ -1280,7 +1280,7 @@ class Agent
             return [
                 'type' => 'string',
                 'enum' => [
-                    'values' => array_map(fn($case) => $case->value, $enumClass::cases()),
+                    'values' => array_map(fn ($case) => $case->value, $enumClass::cases()),
                     'enumClass' => $enumClass, // Store the enum class name for conversion
                 ],
             ];

--- a/src/Drivers/OpenAi/OpenAiCompatible.php
+++ b/src/Drivers/OpenAi/OpenAiCompatible.php
@@ -18,14 +18,17 @@ class OpenAiCompatible extends BaseOpenAiDriver
         }
     }
 
-    protected function buildClient(string $apiKey, string $baseUrl): mixed
+    protected function buildClient(string $apiKey, string $baseUrl, array $headers = []): mixed
     {
         $client = OpenAI::factory()
             ->withApiKey($apiKey)
             ->withBaseUri($baseUrl)
-            ->withHttpClient($httpClient = new \GuzzleHttp\Client([]))
-            ->make();
+            ->withHttpClient($httpClient = new \GuzzleHttp\Client([]));
 
-        return $client;
+        foreach ($headers as $key => $value) {
+            $client->withHttpHeader($key, $value);
+        }
+
+        return $client->make();
     }
 }

--- a/src/Drivers/OpenAi/OpenRouter.php
+++ b/src/Drivers/OpenAi/OpenRouter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LarAgent\Drivers\OpenAi;
+
+class OpenRouter extends OpenAiCompatible
+{
+    protected string $default_api_url = 'https://openrouter.ai/api/v1';
+
+    protected string $referer = 'https://laragent.ai/';
+
+    protected string $title = 'LarAgent';
+
+    public function __construct(array $provider = [])
+    {
+        // Set default values
+        $provider['api_url'] = $provider['api_url'] ?? $this->default_api_url;
+        $this->referer = $provider['referer'] ?? $this->referer;
+        $this->title = $provider['title'] ?? $this->title;
+
+        // Construct parent class and client
+        parent::__construct($provider);
+        $this->client = $this->buildClient($provider['api_key'], $provider['api_url'], [
+            "HTTP-Referer" => $this->referer,
+            "X-Title" => $this->title,
+        ]);
+    }
+}

--- a/src/Drivers/OpenAi/OpenRouter.php
+++ b/src/Drivers/OpenAi/OpenRouter.php
@@ -20,8 +20,8 @@ class OpenRouter extends OpenAiCompatible
         // Construct parent class and client
         parent::__construct($provider);
         $this->client = $this->buildClient($provider['api_key'], $provider['api_url'], [
-            "HTTP-Referer" => $this->referer,
-            "X-Title" => $this->title,
+            'HTTP-Referer' => $this->referer,
+            'X-Title' => $this->title,
         ]);
     }
 }

--- a/testsManual/.gitignore
+++ b/testsManual/.gitignore
@@ -1,4 +1,6 @@
 groq-api-key.php
+openrouter-api-key.php
 openai-api-key.php
 gemini-api-key.php
 anthropic-api-key.php
+*api-key.php

--- a/testsManual/GroqDriverTest.php
+++ b/testsManual/GroqDriverTest.php
@@ -417,7 +417,6 @@ it('can stream with multiple tools use', function () {
     expect(strtolower($output))->toContain('kuala lumpur')->toContain('tokyo')->toContain('celsius');
 });
 
-
 it('can use tool', function () {
     $agent = ToolTestAgent::for('tool_test');
 

--- a/testsManual/OpenRouterDriverTest.php
+++ b/testsManual/OpenRouterDriverTest.php
@@ -1,0 +1,314 @@
+<?php
+
+use LarAgent\Agent;
+use LarAgent\Drivers\OpenAi\OpenRouter;
+use LarAgent\Tests\TestCase;
+use LarAgent\Tool;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $yourApiKey = include 'openrouter-api-key.php';
+
+    config()->set('laragent.fallback_provider', 'openrouter');
+
+    config()->set('laragent.providers.openrouter', [
+        'label' => 'openrouter',
+        'model' => 'deepseek/deepseek-chat-v3.1:free', // Using a free model for testing
+        'api_key' => $yourApiKey,
+        'driver' => OpenRouter::class,
+        'default_context_window' => 200000,
+        'default_max_completion_tokens' => 8192,
+        'default_temperature' => 0.9,
+        'referer' => 'https://laragent.ai/',
+        'title' => 'LarAgent',
+    ]);
+});
+
+// WeatherTool class
+class WeatherTool extends Tool
+{
+    protected string $name = 'get_current_weather';
+
+    protected string $description = 'Get the current weather in a given country.Respond using the word "celsius" or "fahrenheit" instead of symbols like °C or °F.';
+
+    protected array $properties = [
+        'location' => [
+            'type' => 'string',
+            'description' => 'The country, e.g Malaysia, Singapore',
+        ],
+        'unit' => [
+            'type' => 'string',
+            'description' => 'The unit of temperature',
+            'enum' => ['celsius', 'fahrenheit'],
+        ],
+    ];
+
+    protected array $required = ['location'];
+
+    protected array $metaData = ['sent_at' => '2025-07-01'];
+
+    public function execute(array $input): mixed
+    {
+        $location = $input['location'] ?? 'unknown location';
+        $unit = $input['unit'] ?? 'celsius';
+
+        if (strtolower($location) == 'malaysia') {
+            $temperature = '32';
+        } else {
+            $temperature = '33';
+        }
+
+        return [
+            'location' => $location,
+            'unit' => $unit,
+            'temperature' => $temperature,
+        ];
+    }
+}
+
+// TemperatureTool for parallelToolCalls test
+class TemperatureTool extends Tool
+{
+    protected string $name = 'get_temperature';
+
+    protected string $description = 'Get the temperature for a given city';
+
+    protected array $properties = [
+        'location' => [
+            'type' => 'string',
+            'description' => 'The name of the city',
+        ],
+    ];
+
+    protected array $required = ['location'];
+
+    protected array $metaData = ['sent_at' => '2025-07-01'];
+
+    public function execute(array $input): mixed
+    {
+        $temperatures = [
+            'Kuala Lumpur' => '32 celsius',
+            'Tokyo' => '26 celsius',
+        ];
+
+        return $temperatures[$input['location']] ?? 'Temperature data not available';
+    }
+}
+
+// WeatherConditionTool for parallelToolCalls test
+class WeatherConditionTool extends Tool
+{
+    protected string $name = 'get_weather_condition';
+
+    protected string $description = 'Get the weather condition for a given city';
+
+    protected array $properties = [
+        'location' => [
+            'type' => 'string',
+            'description' => 'The name of the city',
+        ],
+    ];
+
+    protected array $required = ['location'];
+
+    protected array $metaData = ['sent_at' => '2025-07-01'];
+
+    public function execute(array $input): mixed
+    {
+        $conditions = [
+            'Kuala Lumpur' => 'Sunny',
+            'Tokyo' => 'Rainy',
+        ];
+
+        return $conditions[$input['location']] ?? 'Weather condition data not available';
+    }
+}
+
+// Test Agent
+class OpenRouterTestAgent extends Agent
+{
+    protected $provider = 'openrouter';
+
+    protected $history = 'in_memory';
+
+    public function instructions()
+    {
+        return 'You are a helpful assistant';
+    }
+
+    public function prompt($message)
+    {
+        return $message.' Please respond and follow instruction appropriately.';
+    }
+}
+
+// Test Agent using WeatherTool
+class ToolTestAgent extends OpenRouterTestAgent
+{
+    public $saveToolResult = null;
+
+    public function instructions()
+    {
+        return <<<'EOT'
+        You are a weather assistant. Always use the available tools to retrieve weather data.
+        For any user request, do the following:
+        - Call the tool to get temperature and weather for the location.
+        - Respond only using the tool result, especially the summary field.
+        - Do not include any extra notes, disclaimers, or general explanations.
+        EOT;
+    }
+
+    public function prompt($message)
+    {
+        return 'Use the tools to complete this request. '.$message;
+    }
+
+    public function registerTools()
+    {
+        return [
+            new WeatherTool,
+        ];
+    }
+
+    protected function afterToolExecution($tool, &$result)
+    {
+        $this->saveToolResult = $result;
+    }
+}
+
+// Test Agent using parallel tools
+class ParallelToolTestAgent extends OpenRouterTestAgent
+{
+    public $toolCalls = [];
+
+    public function instructions()
+    {
+        return <<<'EOT'
+        You are a weather assistant. Always use the available tools to fetch temperature and weather condition.
+
+        Your task:
+        - Call tools to get temperature and condition for each city
+        - Then reply with exactly one sentence per city in the format:
+        "{City} is currently {condition} with a temperature of {temperature}."
+
+        Do not include disclaimers, apologies, or additional commentary.
+        EOT;
+    }
+
+    public function prompt($message)
+    {
+        return 'Use the tools to complete this request. '.$message;
+    }
+
+    public function registerTools()
+    {
+        return [
+            new TemperatureTool,
+            new WeatherConditionTool,
+        ];
+    }
+
+    protected function afterToolExecution($tool, &$result)
+    {
+        $this->toolCalls[] = [
+            'tool' => $tool->getName(),
+            'result' => $result,
+        ];
+    }
+}
+
+// Streaming Tests Only
+
+it('can stream responses using respondStreamed', function () {
+    $agent = OpenRouterTestAgent::for('response_streamed_test');
+
+    // Get the stream
+    $stream = $agent->respondStreamed('Say anything and end your response with "This is a streaming response"');
+
+    // Verify the stream is a Generator
+    expect($stream)->toBeInstanceOf(\Generator::class);
+
+    // Collect all messages from the stream
+    $messages = [];
+    foreach ($stream as $message) {
+        $messages[] = $message;
+    }
+
+    // Verify we received messages
+    expect($messages)->not->toBeEmpty();
+
+    // Check the content of the last message
+    $lastMessage = end($messages);
+    expect($lastMessage->getContent() ?? $lastMessage)->toContain('This is a streaming response');
+});
+
+it('can stream responses using streamResponse in plain format', function () {
+    $agent = OpenRouterTestAgent::for('stream_response_test');
+
+    // Get the response
+    $response = $agent->streamResponse('Say anything and end your response with "This is a streaming response"', 'plain');
+
+    // Verify it's a StreamedResponse
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    // Check headers directly from the response object
+    expect($response->headers->get('Content-Type'))->toBe('text/plain');
+
+    // Capture the streamed output
+    ob_start();
+    ob_start();
+    $response->sendContent();
+    ob_get_clean(); // inner buffer flushed by response
+    $output = ob_get_clean();
+
+    // Ensure the body contains the expected text
+    expect($output)->toContain('This is a streaming response');
+});
+
+it('can stream with tools use', function () {
+    $agent = ToolTestAgent::for('stream_response_test');
+
+    // Get the response
+    $response = $agent->streamResponse('What is the current weather in Malaysia in celsius?', 'plain');
+
+    // Verify it's a StreamedResponse
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    // Check headers directly from the response object
+    expect($response->headers->get('Content-Type'))->toBe('text/plain');
+
+    // Capture the streamed output
+    ob_start();
+    ob_start();
+    $response->sendContent();
+    ob_get_clean(); // inner buffer flushed by response
+    $output = ob_get_clean();
+
+    // Ensure the body contains the expected text
+    expect(strtolower($output))->toContain('malaysia')->toContain('celsius');
+});
+
+it('can stream with multiple tools use', function () {
+    $agent = ParallelToolTestAgent::for('parallel_stream_response_test');
+
+    // Get the response
+    $response = $agent->streamResponse("What's the weather and temperature like in Kuala Lumpur and Tokyo?", 'plain');
+
+    // Verify it's a StreamedResponse
+    expect($response)->toBeInstanceOf(StreamedResponse::class);
+
+    // Check headers directly from the response object
+    expect($response->headers->get('Content-Type'))->toBe('text/plain');
+
+    // Capture the streamed output
+    ob_start();
+    ob_start();
+    $response->sendContent();
+    ob_get_clean(); // inner buffer flushed by response
+    $output = ob_get_clean();
+
+    // Ensure the body contains the expected text
+    expect(strtolower($output))->toContain('kuala lumpur')->toContain('tokyo')->toContain('celsius');
+});


### PR DESCRIPTION
This pull request introduces support for the OpenRouter provider, enabling integration with OpenRouter's API for AI model inference and streaming responses. It also refactors provider configuration, improves agent naming consistency, and adds comprehensive manual tests for the new provider and its tool usage.

**OpenRouter provider integration:**

* Added a new `OpenRouter` driver in `src/Drivers/OpenAi/OpenRouter.php`, which sets up API URL, referer, and title, and passes additional headers when building the client.
* Modified the provider configuration in `config/laragent.php` to include the OpenRouter provider, allowing selection and setup via environment variables.

**Agent and driver improvements:**

* Refactored agent naming: introduced a `setName()` method in `Agent`, replaced `class_basename(static::class)` usage with `$this->name()`, and exposed a public `name()` method for consistent agent identification. [[1]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eR162) [[2]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eR931-R937) [[3]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eL640-R651) [[4]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eL933-R959) [[5]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eL1160-R1178)
* Enhanced the OpenAI-compatible driver to accept custom HTTP headers when building clients, supporting providers like OpenRouter that require additional headers.

**Testing and configuration:**

* Added a comprehensive manual test suite in `testsManual/OpenRouterDriverTest.php` to verify streaming responses, tool integration, and parallel tool execution with OpenRouter.
* Updated `.gitignore` to exclude OpenRouter API key files and all API key files for manual tests.