### PR TITLE
fix: DTO parameter in openAI drivers

### DIFF
--- a/src/Drivers/OpenAi/GeminiDriver.php
+++ b/src/Drivers/OpenAi/GeminiDriver.php
@@ -12,7 +12,7 @@ class GeminiDriver extends OpenAiCompatible
     {
         // Create defaults config, then merge with provided settings (provided takes precedence)
         $defaults = new DriverConfig(
-            api_url: $this->default_url,
+            apiUrl: $this->default_url,
         );
 
         $provided = is_array($settings) ? DriverConfig::fromArray($settings) : $settings;
@@ -20,9 +20,9 @@ class GeminiDriver extends OpenAiCompatible
 
         parent::__construct($settings);
 
-        $apiKey = $this->getDriverConfig()->api_key;
+        $apiKey = $this->getDriverConfig()->apiKey;
         if ($apiKey) {
-            $this->client = $this->buildClient($apiKey, $this->getDriverConfig()->api_url);
+            $this->client = $this->buildClient($apiKey, $this->getDriverConfig()->apiUrl);
         } else {
             throw new \Exception('GeminiDriver driver requires api_key in provider settings.');
         }

--- a/src/Drivers/OpenAi/OllamaDriver.php
+++ b/src/Drivers/OpenAi/OllamaDriver.php
@@ -14,8 +14,8 @@ class OllamaDriver extends OpenAiCompatible
     {
         // Create defaults config, then merge with provided settings (provided takes precedence)
         $defaults = new DriverConfig(
-            api_key: $this->default_api_key,
-            api_url: $this->default_api_url,
+            apiKey: $this->default_api_key,
+            apiUrl: $this->default_api_url,
         );
 
         $provided = is_array($settings) ? DriverConfig::fromArray($settings) : $settings;
@@ -23,8 +23,8 @@ class OllamaDriver extends OpenAiCompatible
 
         parent::__construct($settings);
         $this->client = $this->buildClient(
-            $this->getDriverConfig()->api_key,
-            $this->getDriverConfig()->api_url
+            $this->getDriverConfig()->apiKey,
+            $this->getDriverConfig()->apiUrl
         );
     }
 }


### PR DESCRIPTION
As mentioned in #124, this should fix the issues with `OllamaDriver` and `GeminiDriver`.

It looks like the DTO was updated in a recent version, but the drivers weren’t.

Maybe we could add some tests to make sure this doesn’t happen again in the future?

Also, the docs should be updated to reflect the new apiKey and apiUrl parameters:
https://docs.laragent.ai/quickstart#configuration-file