### PR TITLE
Add OpenAI Responses API driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,10 @@ The following methods are deprecated in all drivers:
 
 ### Added
 
+-   `OpenAiResponsesDriver` for the OpenAI Responses API (`/v1/responses`), required for newer models (e.g. `gpt-5.4-mini`) with `reasoning_effort` support
+-   `OpenAiResponsesMessageFormatter` for Responses API input/output format conversion
+-   `OpenAiResponsesCompatible` driver for third-party providers offering a Responses-API-compatible endpoint
+-   `openai_responses` provider entry in default config
 -   `DriverConfig` DTO for type-safe driver configuration
 -   `DriverConfig::fromArray()`, `::wrap()`, `::merge()`, `::withExtra()` methods
 -   `DriverConfig::set()`, `::get()`, `::has()`, `::getExtra()`, `::getExtras()` methods

--- a/README.md
+++ b/README.md
@@ -298,6 +298,34 @@ You can configure the package by editing the `config/laragent.php` file. Here is
 
 Provider just gives you the defaults. Every config can be overridden per agent in agent class.
 
+#### OpenAI Responses API
+
+For newer OpenAI models that require the Responses API (e.g. models using `reasoning_effort`), use the `OpenAiResponsesDriver`:
+
+```php
+    'openai_responses' => [
+        'label' => 'openai_responses',
+        'api_key' => env('OPENAI_API_KEY'),
+        'driver' => \LarAgent\Drivers\OpenAi\OpenAiResponsesDriver::class,
+        'default_truncation_threshold' => 50000,
+        'default_max_completion_tokens' => 10000,
+        'default_temperature' => 1,
+    ],
+```
+
+You can then use `reasoning_effort` via the agent's `$extras` property:
+
+```php
+class MyReasoningAgent extends Agent
+{
+    protected $provider = 'openai_responses';
+    protected $model = 'gpt-5.4-mini';
+    protected $extras = ['reasoning_effort' => 'high'];
+}
+```
+
+For third-party providers offering a Responses-API-compatible endpoint, use `OpenAiResponsesCompatible` with an `api_url`.
+
 
 ## Contributing
 

--- a/config/laragent.php
+++ b/config/laragent.php
@@ -97,6 +97,15 @@ return [
             'default_temperature' => 1,
         ],
 
+        'openai_responses' => [
+            'label' => 'openai_responses',
+            'api_key' => env('OPENAI_API_KEY'),
+            'driver' => \LarAgent\Drivers\OpenAi\OpenAiResponsesDriver::class,
+            'default_truncation_threshold' => 50000,
+            'default_max_completion_tokens' => 10000,
+            'default_temperature' => 1,
+        ],
+
         'openrouter' => [
             'label' => 'openrouter',
             'api_key' => env('OPENROUTER_API_KEY'),

--- a/src/Drivers/OpenAi/OpenAiResponsesCompatible.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesCompatible.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LarAgent\Drivers\OpenAi;
+
+use LarAgent\Core\DTO\DriverConfig;
+use OpenAI;
+
+/**
+ * OpenAI Responses API compatible driver with custom base URL support.
+ *
+ * Use this for providers that offer a Responses-API-compatible endpoint.
+ */
+class OpenAiResponsesCompatible extends OpenAiResponsesDriver
+{
+    protected string $default_url = 'https://api.openai.com/v1';
+
+    public function __construct(DriverConfig|array $settings = [])
+    {
+        parent::__construct($settings);
+        $apiKey = $this->getDriverConfig()->apiKey;
+        $apiUrl = $this->getDriverConfig()->apiUrl ?? $this->default_url;
+        if ($apiKey) {
+            $this->client = $this->buildClient($apiKey, $apiUrl);
+        } else {
+            throw new \Exception('OpenAiResponsesCompatible driver requires api_key in provider settings.');
+        }
+    }
+
+    protected function buildClient(string $apiKey, string $baseUrl, array $headers = []): mixed
+    {
+        $client = OpenAI::factory()
+            ->withApiKey($apiKey)
+            ->withBaseUri($baseUrl)
+            ->withHttpClient($httpClient = new \GuzzleHttp\Client([]));
+
+        foreach ($headers as $key => $value) {
+            $client->withHttpHeader($key, $value);
+        }
+
+        return $client->make();
+    }
+}

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -231,7 +231,8 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                     ];
                     $hasToolCalls = true;
                 } elseif ($itemType === 'reasoning') {
-                    $reasoningItems[] = $item;
+                    // Strip fields not accepted by the API on input (e.g. status)
+                    $reasoningItems[] = array_intersect_key($item, array_flip(['type', 'id', 'content', 'summary']));
                 }
 
                 continue;

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -230,9 +230,9 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                 $itemType = $item['type'] ?? '';
 
                 if ($itemType === 'function_call') {
-                    $itemId = $item['id'] ?? '';
-                    $callId = $item['call_id'] ?? '';
-                    $name = $item['name'] ?? '';
+                    $itemId = $item['id'];
+                    $callId = $item['call_id'];
+                    $name = $item['name'];
                     $toolCalls[$itemId] = [
                         'call_id' => $callId,
                         'name' => $name,
@@ -246,7 +246,7 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
             // Function call arguments delta - uses item_id to identify the function call
             if ($type === 'response.function_call_arguments.delta') {
-                $itemId = $event['item_id'] ?? '';
+                $itemId = $event['item_id'];
                 $delta = $event['delta'] ?? '';
                 if (isset($toolCalls[$itemId])) {
                     $toolCalls[$itemId]['arguments'] .= $delta;

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -79,11 +79,15 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
         }
 
         // Structured output uses text.format instead of response_format
+        // Responses API expects name, strict, and schema at the format level (not nested under json_schema)
         if ($this->structuredOutputEnabled()) {
+            $wrapped = $this->wrapResponseSchema($this->getResponseSchema());
             $payload['text'] = [
                 'format' => [
                     'type' => 'json_schema',
-                    'json_schema' => $this->wrapResponseSchema($this->getResponseSchema()),
+                    'name' => $wrapped['name'],
+                    'schema' => $wrapped['schema'],
+                    'strict' => $wrapped['strict'] ?? true,
                 ],
             ];
         }

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace LarAgent\Drivers\OpenAi;
+
+use LarAgent\Core\Contracts\MessageFormatter;
+use LarAgent\Core\Contracts\ToolCall as ToolCallInterface;
+use LarAgent\Core\DTO\DriverConfig;
+use LarAgent\Messages\AssistantMessage;
+use LarAgent\Messages\StreamedAssistantMessage;
+use LarAgent\Messages\ToolCallMessage;
+use LarAgent\ToolCall;
+use LarAgent\Usage\DataModels\Usage;
+use OpenAI;
+
+/**
+ * Driver for the OpenAI Responses API (/v1/responses).
+ *
+ * Extends BaseOpenAiDriver to reuse strict-mode schema transformation code,
+ * but overrides message sending and payload preparation for the different API format.
+ */
+class OpenAiResponsesDriver extends BaseOpenAiDriver
+{
+    protected mixed $client;
+
+    public function __construct(DriverConfig|array $settings = [])
+    {
+        parent::__construct($settings);
+        $apiKey = $this->getDriverConfig()->apiKey;
+        $this->client = $apiKey ? OpenAI::client($apiKey) : null;
+    }
+
+    protected function createFormatter(): MessageFormatter
+    {
+        return new OpenAiResponsesMessageFormatter;
+    }
+
+    /**
+     * Prepare the payload for the Responses API.
+     */
+    protected function preparePayload(array $messages, DriverConfig|array $overrideSettings = []): array
+    {
+        $overrideConfig = DriverConfig::wrap($overrideSettings);
+        $config = $this->getDriverConfig()->merge($overrideConfig);
+
+        $payload = [
+            'model' => $config->model ?? 'gpt-4o-mini',
+            'input' => $this->formatter->formatMessages($messages),
+        ];
+
+        if ($config->has('maxCompletionTokens')) {
+            $payload['max_output_tokens'] = $config->maxCompletionTokens;
+        }
+        if ($config->has('temperature')) {
+            $payload['temperature'] = $config->temperature;
+        }
+        if ($config->has('topP')) {
+            $payload['top_p'] = $config->topP;
+        }
+        if ($config->has('toolChoice')) {
+            $payload['tool_choice'] = $config->toolChoice;
+        }
+        if ($config->has('parallelToolCalls')) {
+            $payload['parallel_tool_calls'] = $config->parallelToolCalls;
+        }
+
+        // Handle reasoning_effort via the reasoning field
+        $extras = $config->getExtras();
+        $reasoningEffort = $extras['reasoning_effort'] ?? null;
+        if ($reasoningEffort) {
+            $payload['reasoning'] = ['effort' => $reasoningEffort];
+        }
+
+        // Add remaining extras (excluding reasoning_effort which is handled above)
+        foreach ($extras as $key => $value) {
+            if ($key === 'reasoning_effort') {
+                continue;
+            }
+            $payload[$key] = $value;
+        }
+
+        // Structured output uses text.format instead of response_format
+        if ($this->structuredOutputEnabled()) {
+            $payload['text'] = [
+                'format' => [
+                    'type' => 'json_schema',
+                    'json_schema' => $this->wrapResponseSchema($this->getResponseSchema()),
+                ],
+            ];
+        }
+
+        // Add tools in flat format with strict mode
+        if (! empty($this->tools)) {
+            $tools = $this->formatter->formatTools(array_values($this->tools));
+            $payload['tools'] = $this->transformToolsForResponsesApi($tools);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Transform tool definitions for Responses API strict mode.
+     *
+     * Unlike Chat Completions, Responses API uses flat tool format
+     * (parameters directly on the tool, not nested under 'function').
+     */
+    protected function transformToolsForResponsesApi(array $tools): array
+    {
+        foreach ($tools as $index => $tool) {
+            if (isset($tool['parameters']) && is_array($tool['parameters'])) {
+                $tools[$index]['parameters'] = $this->transformSchemaForStrictMode(
+                    $tool['parameters']
+                );
+                $tools[$index]['strict'] = true;
+            }
+        }
+
+        return $tools;
+    }
+
+    /**
+     * Send a message using the Responses API.
+     */
+    public function sendMessage(array $messages, DriverConfig|array $overrideSettings = []): AssistantMessage
+    {
+        if (empty($this->client)) {
+            throw new \Exception('API key is required to use the OpenAI Responses driver.');
+        }
+
+        $payload = $this->preparePayload($messages, $overrideSettings);
+
+        $this->lastResponse = $this->client->responses()->create($payload);
+        $responseArray = $this->lastResponse->toArray();
+
+        $finishReason = $this->formatter->extractFinishReason($responseArray);
+        $usageData = $this->formatter->extractUsage($responseArray);
+        $usage = ! empty($usageData) ? Usage::fromArray($usageData) : null;
+
+        if (
+            $finishReason === 'tool_calls'
+            || (isset($payload['tool_choice']) && is_array($payload['tool_choice']))
+                && ! empty($this->formatter->extractToolCalls($responseArray))
+        ) {
+            $toolCalls = $this->formatter->extractToolCalls($responseArray);
+            $message = new ToolCallMessage($toolCalls);
+            $message->setUsage($usage);
+
+            return $message;
+        }
+
+        if ($finishReason === 'stop') {
+            $content = $this->formatter->extractContent($responseArray);
+            $message = new AssistantMessage($content);
+            $message->setUsage($usage);
+
+            return $message;
+        }
+
+        throw new \Exception('Unexpected finish reason: '.$finishReason);
+    }
+
+    /**
+     * Send a message using the Responses API with streaming.
+     */
+    public function sendMessageStreamed(array $messages, DriverConfig|array $overrideSettings = [], ?callable $callback = null): \Generator
+    {
+        if (empty($this->client)) {
+            throw new \Exception('API key is required to use the OpenAI Responses driver.');
+        }
+
+        $payload = $this->preparePayload($messages, $overrideSettings);
+
+        $stream = $this->client->responses()->createStreamed($payload);
+
+        $streamedMessage = new StreamedAssistantMessage;
+        $toolCalls = [];
+        $hasToolCalls = false;
+
+        foreach ($stream as $response) {
+            $this->lastResponse = $response;
+            $event = $response->toArray();
+            $type = $event['type'] ?? '';
+
+            // Text content delta
+            if ($type === 'response.output_text.delta') {
+                $delta = $event['delta'] ?? '';
+                $streamedMessage->appendContent($delta);
+
+                if ($callback) {
+                    $callback($streamedMessage);
+                }
+
+                yield $streamedMessage;
+
+                continue;
+            }
+
+            // New output item - track function calls
+            if ($type === 'response.output_item.added') {
+                $item = $event['item'] ?? [];
+                if (($item['type'] ?? '') === 'function_call') {
+                    $callId = $item['call_id'] ?? '';
+                    $name = $item['name'] ?? '';
+                    $toolCalls[$callId] = [
+                        'call_id' => $callId,
+                        'name' => $name,
+                        'arguments' => '',
+                    ];
+                    $hasToolCalls = true;
+                }
+
+                continue;
+            }
+
+            // Function call arguments delta
+            if ($type === 'response.function_call_arguments.delta') {
+                $callId = $event['call_id'] ?? '';
+                $delta = $event['delta'] ?? '';
+                if (isset($toolCalls[$callId])) {
+                    $toolCalls[$callId]['arguments'] .= $delta;
+                }
+
+                continue;
+            }
+
+            // Response completed - extract usage
+            if ($type === 'response.completed') {
+                $responseData = $event['response'] ?? [];
+                $usageData = $responseData['usage'] ?? [];
+                if (! empty($usageData)) {
+                    $streamedMessage->setUsage(new Usage(
+                        $usageData['input_tokens'] ?? 0,
+                        $usageData['output_tokens'] ?? 0,
+                        $usageData['total_tokens'] ?? (($usageData['input_tokens'] ?? 0) + ($usageData['output_tokens'] ?? 0))
+                    ));
+                }
+                $streamedMessage->setComplete(true);
+
+                if ($callback) {
+                    $callback($streamedMessage);
+                }
+
+                yield $streamedMessage;
+
+                continue;
+            }
+        }
+
+        // If we accumulated tool calls, yield a ToolCallMessage
+        if ($hasToolCalls && ! empty($toolCalls)) {
+            $toolCallObjects = array_map(function ($tc) {
+                return new ToolCall(
+                    $tc['call_id'],
+                    $tc['name'],
+                    $tc['arguments'] ?: '{}'
+                );
+            }, array_values($toolCalls));
+
+            $toolCallMessage = new ToolCallMessage($toolCallObjects);
+
+            if ($streamedMessage->getUsage() !== null) {
+                $toolCallMessage->setUsage($streamedMessage->getUsage());
+            }
+
+            if ($callback) {
+                $callback($toolCallMessage);
+            }
+
+            yield $toolCallMessage;
+        }
+    }
+
+    /**
+     * @deprecated Use formatter instead.
+     */
+    public function toolResultToMessage(ToolCallInterface $toolCall, mixed $result): array
+    {
+        $content = json_decode($toolCall->getArguments(), true);
+        $content[$toolCall->getToolName()] = $result;
+
+        return [
+            'type' => 'function_call_output',
+            'call_id' => $toolCall->getId(),
+            'output' => json_encode($content),
+        ];
+    }
+
+    /**
+     * @deprecated Use formatter instead.
+     */
+    public function toolCallsToMessage(array $toolCalls): array
+    {
+        // Return first tool call in Responses API format
+        $first = $toolCalls[0] ?? null;
+        if (! $first) {
+            return [];
+        }
+
+        return [
+            'type' => 'function_call',
+            'call_id' => $first->getId(),
+            'name' => $first->getToolName(),
+            'arguments' => $first->getArguments(),
+        ];
+    }
+}

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -176,7 +176,8 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
         $stream = $this->client->responses()->createStreamed($payload);
 
         $streamedMessage = new StreamedAssistantMessage;
-        $toolCalls = [];
+        $toolCalls = [];        // Keyed by item_id
+        $itemIdToCallId = [];   // Maps item_id -> call_id for argument deltas
         $hasToolCalls = false;
 
         foreach ($stream as $response) {
@@ -202,25 +203,27 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
             if ($type === 'response.output_item.added') {
                 $item = $event['item'] ?? [];
                 if (($item['type'] ?? '') === 'function_call') {
+                    $itemId = $item['id'] ?? '';
                     $callId = $item['call_id'] ?? '';
                     $name = $item['name'] ?? '';
-                    $toolCalls[$callId] = [
+                    $toolCalls[$itemId] = [
                         'call_id' => $callId,
                         'name' => $name,
                         'arguments' => '',
                     ];
+                    $itemIdToCallId[$itemId] = $callId;
                     $hasToolCalls = true;
                 }
 
                 continue;
             }
 
-            // Function call arguments delta
+            // Function call arguments delta - uses item_id to identify the function call
             if ($type === 'response.function_call_arguments.delta') {
-                $callId = $event['call_id'] ?? '';
+                $itemId = $event['item_id'] ?? '';
                 $delta = $event['delta'] ?? '';
-                if (isset($toolCalls[$callId])) {
-                    $toolCalls[$callId]['arguments'] .= $delta;
+                if (isset($toolCalls[$itemId])) {
+                    $toolCalls[$itemId]['arguments'] .= $delta;
                 }
 
                 continue;

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -78,6 +78,13 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
         $reasoningEffort = $extras['reasoning_effort'] ?? null;
         if ($reasoningEffort) {
             $payload['reasoning'] = ['effort' => $reasoningEffort];
+
+            // Request encrypted reasoning content so reasoning items can be
+            // replayed in subsequent turns for stateless multi-turn conversations.
+            $payload['include'] = array_unique(array_merge(
+                $payload['include'] ?? [],
+                ['reasoning.encrypted_content']
+            ));
         }
 
         // Add remaining extras (excluding reasoning_effort which is handled above)
@@ -158,10 +165,12 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
             $message = new ToolCallMessage($toolCalls);
             $message->setUsage($usage);
 
-            // Store reasoning items so they can be passed back with tool call outputs
-            $reasoningItems = $this->formatter->extractReasoningItems($responseArray);
-            if (! empty($reasoningItems)) {
-                $message->setExtra('reasoning_items', $reasoningItems);
+            // Store raw output items (reasoning + function_call) so they can be replayed
+            // exactly as the API returned them. Reasoning models require the complete
+            // output items (with their id fields) to be passed back.
+            $rawOutputItems = $this->formatter->extractOutputItemsForReplay($responseArray);
+            if (! empty($rawOutputItems)) {
+                $message->setExtra('raw_output_items', $rawOutputItems);
             }
 
             return $message;
@@ -193,7 +202,7 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
         $streamedMessage = new StreamedAssistantMessage;
         $toolCalls = [];        // Keyed by item_id
-        $reasoningItems = [];   // Reasoning items to pass back
+        $rawOutputItems = null; // Complete output items from response.completed
         $hasToolCalls = false;
 
         foreach ($stream as $response) {
@@ -215,7 +224,7 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                 continue;
             }
 
-            // New output item - track function calls and reasoning items
+            // New output item - track function calls
             if ($type === 'response.output_item.added') {
                 $item = $event['item'] ?? [];
                 $itemType = $item['type'] ?? '';
@@ -230,9 +239,6 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                         'arguments' => '',
                     ];
                     $hasToolCalls = true;
-                } elseif ($itemType === 'reasoning') {
-                    // Strip fields not accepted by the API on input (e.g. status)
-                    $reasoningItems[] = array_intersect_key($item, array_flip(['type', 'id', 'content', 'summary']));
                 }
 
                 continue;
@@ -249,7 +255,7 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                 continue;
             }
 
-            // Response completed - extract usage and full reasoning items
+            // Response completed - extract usage and raw output items
             if ($type === 'response.completed') {
                 $responseData = $event['response'] ?? [];
                 $usageData = $responseData['usage'] ?? [];
@@ -261,11 +267,8 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                     ));
                 }
 
-                // Extract full reasoning items from completed response
-                $completedReasoningItems = $this->formatter->extractReasoningItems($responseData);
-                if (! empty($completedReasoningItems)) {
-                    $reasoningItems = $completedReasoningItems;
-                }
+                // Extract complete output items for faithful replay
+                $rawOutputItems = $this->formatter->extractOutputItemsForReplay($responseData);
 
                 $streamedMessage->setComplete(true);
 
@@ -291,9 +294,9 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
             $toolCallMessage = new ToolCallMessage($toolCallObjects);
 
-            // Store reasoning items so they can be passed back with tool call outputs
-            if (! empty($reasoningItems)) {
-                $toolCallMessage->setExtra('reasoning_items', $reasoningItems);
+            // Store raw output items for faithful replay on next request
+            if (! empty($rawOutputItems)) {
+                $toolCallMessage->setExtra('raw_output_items', $rawOutputItems);
             }
 
             if ($streamedMessage->getUsage() !== null) {

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -42,10 +42,20 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
         $overrideConfig = DriverConfig::wrap($overrideSettings);
         $config = $this->getDriverConfig()->merge($overrideConfig);
 
+        $formattedInput = $this->formatter->formatMessages($messages);
+
+        // Extract the first system/developer message as the instructions parameter
+        $instructions = null;
+        $formattedInput = $this->extractInstructions($formattedInput, $instructions);
+
         $payload = [
             'model' => $config->model ?? 'gpt-4o-mini',
-            'input' => $this->formatter->formatMessages($messages),
+            'input' => $formattedInput,
         ];
+
+        if ($instructions !== null) {
+            $payload['instructions'] = $instructions;
+        }
 
         if ($config->has('maxCompletionTokens')) {
             $payload['max_output_tokens'] = $config->maxCompletionTokens;
@@ -139,14 +149,20 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
         $usageData = $this->formatter->extractUsage($responseArray);
         $usage = ! empty($usageData) ? Usage::fromArray($usageData) : null;
 
+        $toolCalls = $this->formatter->extractToolCalls($responseArray);
+
         if (
             $finishReason === 'tool_calls'
-            || (isset($payload['tool_choice']) && is_array($payload['tool_choice']))
-                && ! empty($this->formatter->extractToolCalls($responseArray))
+            || (isset($payload['tool_choice']) && is_array($payload['tool_choice']) && ! empty($toolCalls))
         ) {
-            $toolCalls = $this->formatter->extractToolCalls($responseArray);
             $message = new ToolCallMessage($toolCalls);
             $message->setUsage($usage);
+
+            // Store reasoning items so they can be passed back with tool call outputs
+            $reasoningItems = $this->formatter->extractReasoningItems($responseArray);
+            if (! empty($reasoningItems)) {
+                $message->setExtra('reasoning_items', $reasoningItems);
+            }
 
             return $message;
         }
@@ -177,6 +193,7 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
         $streamedMessage = new StreamedAssistantMessage;
         $toolCalls = [];        // Keyed by item_id
+        $reasoningItems = [];   // Reasoning items to pass back
         $hasToolCalls = false;
 
         foreach ($stream as $response) {
@@ -198,10 +215,12 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                 continue;
             }
 
-            // New output item - track function calls
+            // New output item - track function calls and reasoning items
             if ($type === 'response.output_item.added') {
                 $item = $event['item'] ?? [];
-                if (($item['type'] ?? '') === 'function_call') {
+                $itemType = $item['type'] ?? '';
+
+                if ($itemType === 'function_call') {
                     $itemId = $item['id'] ?? '';
                     $callId = $item['call_id'] ?? '';
                     $name = $item['name'] ?? '';
@@ -211,6 +230,8 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                         'arguments' => '',
                     ];
                     $hasToolCalls = true;
+                } elseif ($itemType === 'reasoning') {
+                    $reasoningItems[] = $item;
                 }
 
                 continue;
@@ -227,7 +248,7 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                 continue;
             }
 
-            // Response completed - extract usage
+            // Response completed - extract usage and full reasoning items
             if ($type === 'response.completed') {
                 $responseData = $event['response'] ?? [];
                 $usageData = $responseData['usage'] ?? [];
@@ -238,6 +259,13 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                         $usageData['total_tokens'] ?? (($usageData['input_tokens'] ?? 0) + ($usageData['output_tokens'] ?? 0))
                     ));
                 }
+
+                // Extract full reasoning items from completed response
+                $completedReasoningItems = $this->formatter->extractReasoningItems($responseData);
+                if (! empty($completedReasoningItems)) {
+                    $reasoningItems = $completedReasoningItems;
+                }
+
                 $streamedMessage->setComplete(true);
 
                 if ($callback) {
@@ -262,6 +290,11 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
             $toolCallMessage = new ToolCallMessage($toolCallObjects);
 
+            // Store reasoning items so they can be passed back with tool call outputs
+            if (! empty($reasoningItems)) {
+                $toolCallMessage->setExtra('reasoning_items', $reasoningItems);
+            }
+
             if ($streamedMessage->getUsage() !== null) {
                 $toolCallMessage->setUsage($streamedMessage->getUsage());
             }
@@ -272,6 +305,37 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
             yield $toolCallMessage;
         }
+    }
+
+    /**
+     * Extract the first system or developer message from formatted input
+     * and return it as the instructions string.
+     *
+     * The Responses API has a dedicated `instructions` parameter that gives
+     * high-level instructions priority over input messages.
+     */
+    protected function extractInstructions(array $formattedInput, ?string &$instructions): array
+    {
+        foreach ($formattedInput as $index => $item) {
+            if (
+                ($item['type'] ?? '') === 'message'
+                && in_array($item['role'] ?? '', ['system', 'developer'])
+            ) {
+                // Extract text from the content array
+                $text = '';
+                foreach ($item['content'] ?? [] as $part) {
+                    if (isset($part['text'])) {
+                        $text .= $part['text'];
+                    }
+                }
+                $instructions = $text;
+                array_splice($formattedInput, $index, 1);
+
+                return $formattedInput;
+            }
+        }
+
+        return $formattedInput;
     }
 
     /**

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -207,8 +207,8 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
         foreach ($stream as $response) {
             $this->lastResponse = $response;
-            $event = $response->toArray();
-            $type = $event['type'] ?? '';
+            $type = $response->event;
+            $event = $response->response->toArray();
 
             // Text content delta
             if ($type === 'response.output_text.delta') {

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -177,7 +177,6 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
 
         $streamedMessage = new StreamedAssistantMessage;
         $toolCalls = [];        // Keyed by item_id
-        $itemIdToCallId = [];   // Maps item_id -> call_id for argument deltas
         $hasToolCalls = false;
 
         foreach ($stream as $response) {
@@ -211,7 +210,6 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                         'name' => $name,
                         'arguments' => '',
                     ];
-                    $itemIdToCallId[$itemId] = $callId;
                     $hasToolCalls = true;
                 }
 

--- a/src/Drivers/OpenAi/OpenAiResponsesDriver.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesDriver.php
@@ -229,8 +229,11 @@ class OpenAiResponsesDriver extends BaseOpenAiDriver
                 $item = $event['item'] ?? [];
                 $itemType = $item['type'] ?? '';
 
+                // call_id and name are required per the API spec, but id is
+                // optional (see openai/openai-python#2205), so we fall back
+                // to a unique key to avoid collisions in $toolCalls.
                 if ($itemType === 'function_call') {
-                    $itemId = $item['id'];
+                    $itemId = $item['id'] ?? uniqid('fc_');
                     $callId = $item['call_id'];
                     $name = $item['name'];
                     $toolCalls[$itemId] = [

--- a/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
@@ -57,12 +57,23 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
      * Convert an array of LarAgent messages to Responses API input format.
      *
      * ToolCallMessages are flattened into separate function_call items.
+     * Reasoning items stored on ToolCallMessages are included before function_call items,
+     * as required by reasoning models (GPT-5, o-series).
      */
     public function formatMessages(array $messages): array
     {
         $formatted = [];
         foreach ($messages as $message) {
             if ($message instanceof ToolCallMessage) {
+                // Include reasoning items before function_call items if present
+                // Reasoning models require these to be passed back with tool call outputs
+                $reasoningItems = $message->hasExtra('reasoning_items')
+                    ? $message->getExtra('reasoning_items')
+                    : [];
+                foreach ($reasoningItems as $reasoningItem) {
+                    $formatted[] = $reasoningItem;
+                }
+
                 // Each tool call becomes a separate function_call input item
                 foreach ($message->getToolCalls() as $toolCall) {
                     $formatted[] = [
@@ -142,6 +153,26 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
     }
 
     /**
+     * Extract reasoning items from Responses API response output.
+     *
+     * Reasoning models (GPT-5, o-series) return reasoning items that must
+     * be passed back in subsequent requests when doing tool calling.
+     */
+    public function extractReasoningItems(array $response): array
+    {
+        $items = [];
+        $output = $response['output'] ?? [];
+
+        foreach ($output as $item) {
+            if (($item['type'] ?? '') === 'reasoning') {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
      * Extract and normalize finish reason from Responses API response.
      *
      * Detection: if output contains function_call items -> 'tool_calls',
@@ -203,8 +234,14 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
                 $parts[] = ['type' => 'input_text', 'text' => $part];
             } elseif (isset($part['type']) && $part['type'] === 'text') {
                 $parts[] = ['type' => 'input_text', 'text' => $part['text']];
+            } elseif (isset($part['type']) && $part['type'] === 'image_url') {
+                // Map Chat Completions image_url format to Responses API input_image format
+                $parts[] = [
+                    'type' => 'input_image',
+                    'image_url' => $part['image_url']['url'] ?? $part['image_url'] ?? '',
+                ];
             } else {
-                // Pass through other content types (images, etc.)
+                // Pass through other content types
                 $parts[] = $part;
             }
         }

--- a/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace LarAgent\Drivers\OpenAi;
+
+use LarAgent\Core\Contracts\Message as MessageInterface;
+use LarAgent\Core\Contracts\MessageFormatter;
+use LarAgent\Core\Contracts\Tool as ToolInterface;
+use LarAgent\Messages\ToolCallMessage;
+use LarAgent\Messages\ToolResultMessage;
+use LarAgent\Messages\UserMessage;
+use LarAgent\ToolCall;
+
+/**
+ * Message formatter for the OpenAI Responses API.
+ *
+ * Converts between LarAgent message objects and the Responses API
+ * input/output format, which differs from Chat Completions.
+ */
+class OpenAiResponsesMessageFormatter implements MessageFormatter
+{
+    // ========== LarAgent → Driver (formatting for API request) ==========
+
+    /**
+     * Convert a single LarAgent message to Responses API input item format.
+     *
+     * Note: ToolCallMessage returns multiple items (one per tool call),
+     * so formatMessages() handles flattening.
+     */
+    public function formatMessage(MessageInterface $message): array
+    {
+        if ($message instanceof ToolResultMessage) {
+            return $this->formatToolResultMessage($message);
+        }
+
+        if ($message instanceof ToolCallMessage) {
+            return $this->formatToolCallMessage($message);
+        }
+
+        if ($message instanceof UserMessage) {
+            return $this->formatUserMessage($message);
+        }
+
+        // System, Developer, Assistant messages
+        $role = $message->getRole();
+        $contentType = ($role === 'assistant') ? 'output_text' : 'input_text';
+
+        return [
+            'type' => 'message',
+            'role' => $role,
+            'content' => [
+                ['type' => $contentType, 'text' => $message->getContentAsString()],
+            ],
+        ];
+    }
+
+    /**
+     * Convert an array of LarAgent messages to Responses API input format.
+     *
+     * ToolCallMessages are flattened into separate function_call items.
+     */
+    public function formatMessages(array $messages): array
+    {
+        $formatted = [];
+        foreach ($messages as $message) {
+            if ($message instanceof ToolCallMessage) {
+                // Each tool call becomes a separate function_call input item
+                foreach ($message->getToolCalls() as $toolCall) {
+                    $formatted[] = [
+                        'type' => 'function_call',
+                        'call_id' => $toolCall->getId(),
+                        'name' => $toolCall->getToolName(),
+                        'arguments' => $toolCall->getArguments(),
+                    ];
+                }
+            } else {
+                $formatted[] = $this->formatMessage($message);
+            }
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * Convert LarAgent tools to Responses API flat tool format.
+     */
+    public function formatTools(array $tools): array
+    {
+        $formatted = [];
+        foreach ($tools as $tool) {
+            $formatted[] = $this->formatTool($tool);
+        }
+
+        return $formatted;
+    }
+
+    // ========== Driver → LarAgent (extracting from API response) ==========
+
+    /**
+     * Extract usage from Responses API response.
+     * Maps input_tokens/output_tokens to normalized keys.
+     */
+    public function extractUsage(array $response): array
+    {
+        $usage = $response['usage'] ?? [];
+
+        return [
+            'prompt_tokens' => $usage['input_tokens'] ?? 0,
+            'completion_tokens' => $usage['output_tokens'] ?? 0,
+            'total_tokens' => $usage['total_tokens'] ?? (($usage['input_tokens'] ?? 0) + ($usage['output_tokens'] ?? 0)),
+        ];
+    }
+
+    /**
+     * Extract tool calls from Responses API response.
+     * Filters output items for type === 'function_call'.
+     */
+    public function extractToolCalls(array $response): array
+    {
+        $toolCalls = [];
+        $output = $response['output'] ?? [];
+
+        foreach ($output as $item) {
+            if (($item['type'] ?? '') === 'function_call') {
+                $toolCalls[] = new ToolCall(
+                    $item['call_id'],
+                    $item['name'],
+                    $item['arguments']
+                );
+            }
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * Extract text content from Responses API response.
+     * Uses the convenience output_text field.
+     */
+    public function extractContent(array $response): string
+    {
+        return $response['output_text'] ?? '';
+    }
+
+    /**
+     * Extract and normalize finish reason from Responses API response.
+     *
+     * Detection: if output contains function_call items -> 'tool_calls',
+     * otherwise map status: 'completed' -> 'stop', 'incomplete' -> 'length'.
+     */
+    public function extractFinishReason(array $response): string
+    {
+        // Check if output contains function_call items
+        $output = $response['output'] ?? [];
+        foreach ($output as $item) {
+            if (($item['type'] ?? '') === 'function_call') {
+                return 'tool_calls';
+            }
+        }
+
+        // Map status to normalized finish reason
+        $status = $response['status'] ?? 'completed';
+
+        return match ($status) {
+            'completed' => 'stop',
+            'incomplete' => 'length',
+            'failed' => 'stop',
+            default => 'stop',
+        };
+    }
+
+    // ========== Helper methods ==========
+
+    protected function formatUserMessage(UserMessage $message): array
+    {
+        $content = $message->getContent();
+
+        if ($content === null) {
+            return [
+                'type' => 'message',
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'input_text', 'text' => ''],
+                ],
+            ];
+        }
+
+        // For multimodal content, convert to array and wrap text parts
+        $contentArray = $content->toArray();
+        if (is_string($contentArray)) {
+            return [
+                'type' => 'message',
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'input_text', 'text' => $contentArray],
+                ],
+            ];
+        }
+
+        // Map content parts to Responses API format
+        $parts = [];
+        foreach ($contentArray as $part) {
+            if (is_string($part)) {
+                $parts[] = ['type' => 'input_text', 'text' => $part];
+            } elseif (isset($part['type']) && $part['type'] === 'text') {
+                $parts[] = ['type' => 'input_text', 'text' => $part['text']];
+            } else {
+                // Pass through other content types (images, etc.)
+                $parts[] = $part;
+            }
+        }
+
+        return [
+            'type' => 'message',
+            'role' => 'user',
+            'content' => $parts,
+        ];
+    }
+
+    /**
+     * Format a ToolCallMessage. Returns array of function_call items.
+     * Note: This is only used when formatting a single message; formatMessages() handles flattening.
+     */
+    protected function formatToolCallMessage(ToolCallMessage $message): array
+    {
+        // Return first tool call as single item (for formatMessage contract)
+        $toolCalls = $message->getToolCalls();
+        $first = $toolCalls[0] ?? null;
+
+        if (! $first) {
+            return [];
+        }
+
+        return [
+            'type' => 'function_call',
+            'call_id' => $first->getId(),
+            'name' => $first->getToolName(),
+            'arguments' => $first->getArguments(),
+        ];
+    }
+
+    protected function formatToolResultMessage(ToolResultMessage $message): array
+    {
+        return [
+            'type' => 'function_call_output',
+            'call_id' => $message->getToolCallId(),
+            'output' => $message->getContentAsString(),
+        ];
+    }
+
+    /**
+     * Format a single tool for Responses API payload.
+     * Uses flat structure (no 'function' wrapper).
+     */
+    protected function formatTool(ToolInterface $tool): array
+    {
+        $toolSchema = [
+            'type' => 'function',
+            'name' => $tool->getName(),
+            'description' => $tool->getDescription(),
+        ];
+
+        if (! empty($tool->getProperties())) {
+            $toolSchema['parameters'] = [
+                'type' => 'object',
+                'properties' => $tool->getProperties(),
+                'required' => $tool->getRequired(),
+            ];
+        }
+
+        return $toolSchema;
+    }
+}

--- a/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
@@ -65,23 +65,24 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
         $formatted = [];
         foreach ($messages as $message) {
             if ($message instanceof ToolCallMessage) {
-                // Include reasoning items before function_call items if present
-                // Reasoning models require these to be passed back with tool call outputs
-                $reasoningItems = $message->hasExtra('reasoning_items')
-                    ? $message->getExtra('reasoning_items')
-                    : [];
-                foreach ($reasoningItems as $reasoningItem) {
-                    $formatted[] = $this->sanitizeReasoningItem($reasoningItem);
-                }
-
-                // Each tool call becomes a separate function_call input item
-                foreach ($message->getToolCalls() as $toolCall) {
-                    $formatted[] = [
-                        'type' => 'function_call',
-                        'call_id' => $toolCall->getId(),
-                        'name' => $toolCall->getToolName(),
-                        'arguments' => $toolCall->getArguments(),
-                    ];
+                // If raw output items are available (from a Responses API response),
+                // replay them faithfully. This preserves item ids and reasoning items
+                // in the correct order, which reasoning models require.
+                if ($message->hasExtra('raw_output_items')) {
+                    foreach ($message->getExtra('raw_output_items') as $item) {
+                        $formatted[] = $item;
+                    }
+                } else {
+                    // Fallback: reconstruct function_call items from ToolCall objects
+                    // (used when messages are restored from storage without raw items)
+                    foreach ($message->getToolCalls() as $toolCall) {
+                        $formatted[] = [
+                            'type' => 'function_call',
+                            'call_id' => $toolCall->getId(),
+                            'name' => $toolCall->getToolName(),
+                            'arguments' => $toolCall->getArguments(),
+                        ];
+                    }
                 }
             } else {
                 $formatted[] = $this->formatMessage($message);
@@ -153,31 +154,24 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
     }
 
     /**
-     * Extract reasoning items from Responses API response output.
+     * Extract output items (reasoning + function_call) for faithful replay.
      *
-     * Reasoning models (GPT-5, o-series) return reasoning items that must
-     * be passed back in subsequent requests when doing tool calling.
-     * Only keeps fields accepted by the API on input (strips status, etc.).
+     * Reasoning models require the complete output items (with their id fields)
+     * to be passed back in subsequent requests. This preserves reasoning items
+     * alongside their associated function_call items in the correct order.
+     * Null values are filtered out since the API rejects null for optional
+     * enum fields like status.
      */
-    public function extractReasoningItems(array $response): array
+    public function extractOutputItemsForReplay(array $response): array
     {
         $items = [];
         $output = $response['output'] ?? [];
 
         foreach ($output as $item) {
-            if (($item['type'] ?? '') === 'reasoning') {
-                // Only include fields the API accepts on input
-                $sanitized = [
-                    'type' => 'reasoning',
-                    'id' => $item['id'] ?? null,
-                ];
-                if (isset($item['content'])) {
-                    $sanitized['content'] = $item['content'];
-                }
-                if (isset($item['summary'])) {
-                    $sanitized['summary'] = $item['summary'];
-                }
-                $items[] = array_filter($sanitized, fn ($v) => $v !== null);
+            $type = $item['type'] ?? '';
+
+            if ($type === 'reasoning' || $type === 'function_call') {
+                $items[] = array_filter($item, fn ($v) => $v !== null);
             }
         }
 
@@ -294,15 +288,6 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
             'call_id' => $message->getToolCallId(),
             'output' => $message->getContentAsString(),
         ];
-    }
-
-    /**
-     * Sanitize a reasoning item to only include fields accepted by the API on input.
-     * Strips status and other response-only fields.
-     */
-    protected function sanitizeReasoningItem(array $item): array
-    {
-        return array_intersect_key($item, array_flip(['type', 'id', 'content', 'summary']));
     }
 
     /**

--- a/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
@@ -217,7 +217,7 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
     }
 
     /**
-     * Format a ToolCallMessage. Returns array of function_call items.
+     * Format a ToolCallMessage into a single function_call item.
      * Note: This is only used when formatting a single message; formatMessages() handles flattening.
      */
     protected function formatToolCallMessage(ToolCallMessage $message): array

--- a/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
+++ b/src/Drivers/OpenAi/OpenAiResponsesMessageFormatter.php
@@ -71,7 +71,7 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
                     ? $message->getExtra('reasoning_items')
                     : [];
                 foreach ($reasoningItems as $reasoningItem) {
-                    $formatted[] = $reasoningItem;
+                    $formatted[] = $this->sanitizeReasoningItem($reasoningItem);
                 }
 
                 // Each tool call becomes a separate function_call input item
@@ -157,6 +157,7 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
      *
      * Reasoning models (GPT-5, o-series) return reasoning items that must
      * be passed back in subsequent requests when doing tool calling.
+     * Only keeps fields accepted by the API on input (strips status, etc.).
      */
     public function extractReasoningItems(array $response): array
     {
@@ -165,7 +166,18 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
 
         foreach ($output as $item) {
             if (($item['type'] ?? '') === 'reasoning') {
-                $items[] = $item;
+                // Only include fields the API accepts on input
+                $sanitized = [
+                    'type' => 'reasoning',
+                    'id' => $item['id'] ?? null,
+                ];
+                if (isset($item['content'])) {
+                    $sanitized['content'] = $item['content'];
+                }
+                if (isset($item['summary'])) {
+                    $sanitized['summary'] = $item['summary'];
+                }
+                $items[] = array_filter($sanitized, fn ($v) => $v !== null);
             }
         }
 
@@ -282,6 +294,15 @@ class OpenAiResponsesMessageFormatter implements MessageFormatter
             'call_id' => $message->getToolCallId(),
             'output' => $message->getContentAsString(),
         ];
+    }
+
+    /**
+     * Sanitize a reasoning item to only include fields accepted by the API on input.
+     * Strips status and other response-only fields.
+     */
+    protected function sanitizeReasoningItem(array $item): array
+    {
+        return array_intersect_key($item, array_flip(['type', 'id', 'content', 'summary']));
     }
 
     /**

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesDriverTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesDriverTest.php
@@ -99,6 +99,19 @@ describe('OpenAiResponsesDriver', function () {
             expect($payload)->not->toHaveKey('reasoning_effort');
         });
 
+        it('includes reasoning.encrypted_content when reasoning is enabled', function () {
+            $config = DriverConfig::wrap([
+                'model' => 'o3',
+                'reasoning_effort' => 'medium',
+            ]);
+            $this->driver->setTestConfig($config);
+
+            $payload = $this->driver->publicPreparePayload([]);
+
+            expect($payload)->toHaveKey('include');
+            expect($payload['include'])->toContain('reasoning.encrypted_content');
+        });
+
         it('passes through other extras', function () {
             $config = DriverConfig::wrap([
                 'model' => 'gpt-4o-mini',

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesDriverTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesDriverTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use LarAgent\Core\DTO\DriverConfig;
+use LarAgent\Drivers\OpenAi\OpenAiResponsesDriver;
+use LarAgent\Drivers\OpenAi\OpenAiResponsesMessageFormatter;
+
+// Testable subclass to expose protected methods
+class TestableOpenAiResponsesDriver extends OpenAiResponsesDriver
+{
+    public function __construct()
+    {
+        // Skip parent constructor to avoid API key requirement
+    }
+
+    public function publicPreparePayload(array $messages, DriverConfig|array $overrideSettings = []): array
+    {
+        return $this->preparePayload($messages, $overrideSettings);
+    }
+
+    public function publicTransformToolsForResponsesApi(array $tools): array
+    {
+        return $this->transformToolsForResponsesApi($tools);
+    }
+
+    public function getPublicFormatter(): \LarAgent\Core\Contracts\MessageFormatter
+    {
+        return $this->formatter;
+    }
+
+    // Expose setDriverConfig for testing
+    public function setTestConfig(DriverConfig $config): void
+    {
+        $this->driverConfig = $config;
+    }
+
+    // Initialize formatter for testing
+    public function initForTest(): void
+    {
+        $this->formatter = $this->createFormatter();
+        $this->driverConfig = DriverConfig::wrap([
+            'model' => 'gpt-4o-mini',
+            'temperature' => 0.7,
+            'maxCompletionTokens' => 1000,
+        ]);
+    }
+}
+
+beforeEach(function () {
+    $this->driver = new TestableOpenAiResponsesDriver;
+    $this->driver->initForTest();
+});
+
+describe('OpenAiResponsesDriver', function () {
+    describe('createFormatter()', function () {
+        it('returns an OpenAiResponsesMessageFormatter', function () {
+            expect($this->driver->getPublicFormatter())->toBeInstanceOf(OpenAiResponsesMessageFormatter::class);
+        });
+    });
+
+    describe('preparePayload()', function () {
+        it('uses input instead of messages', function () {
+            $payload = $this->driver->publicPreparePayload([]);
+
+            expect($payload)->toHaveKey('input');
+            expect($payload)->not->toHaveKey('messages');
+        });
+
+        it('uses max_output_tokens instead of max_completion_tokens', function () {
+            $payload = $this->driver->publicPreparePayload([]);
+
+            expect($payload)->toHaveKey('max_output_tokens', 1000);
+            expect($payload)->not->toHaveKey('max_completion_tokens');
+        });
+
+        it('includes model and temperature', function () {
+            $payload = $this->driver->publicPreparePayload([]);
+
+            expect($payload['model'])->toBe('gpt-4o-mini');
+            expect($payload['temperature'])->toBe(0.7);
+        });
+
+        it('maps reasoning_effort to reasoning.effort', function () {
+            $config = DriverConfig::wrap([
+                'model' => 'gpt-4o-mini',
+                'reasoning_effort' => 'high',
+            ]);
+            $this->driver->setTestConfig($config);
+
+            $payload = $this->driver->publicPreparePayload([]);
+
+            expect($payload)->toHaveKey('reasoning');
+            expect($payload['reasoning'])->toBe(['effort' => 'high']);
+            // reasoning_effort should not appear as a top-level key
+            expect($payload)->not->toHaveKey('reasoning_effort');
+        });
+
+        it('passes through other extras', function () {
+            $config = DriverConfig::wrap([
+                'model' => 'gpt-4o-mini',
+                'store' => true,
+            ]);
+            $this->driver->setTestConfig($config);
+
+            $payload = $this->driver->publicPreparePayload([]);
+
+            expect($payload)->toHaveKey('store', true);
+        });
+    });
+
+    describe('transformToolsForResponsesApi()', function () {
+        it('applies strict mode to flat tool format', function () {
+            $tools = [
+                [
+                    'type' => 'function',
+                    'name' => 'get_weather',
+                    'description' => 'Get weather',
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'city' => ['type' => 'string'],
+                        ],
+                        'required' => ['city'],
+                    ],
+                ],
+            ];
+
+            $result = $this->driver->publicTransformToolsForResponsesApi($tools);
+
+            expect($result[0])->toHaveKey('strict', true);
+            expect($result[0]['parameters'])->toHaveKey('additionalProperties', false);
+            // Parameters should be directly on the tool, not nested under 'function'
+            expect($result[0])->not->toHaveKey('function');
+            expect($result[0])->toHaveKey('parameters');
+        });
+
+        it('does not wrap parameters under function key', function () {
+            $tools = [
+                [
+                    'type' => 'function',
+                    'name' => 'test_tool',
+                    'description' => 'Test',
+                    'parameters' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'arg' => ['type' => 'string'],
+                        ],
+                        'required' => ['arg'],
+                    ],
+                ],
+            ];
+
+            $result = $this->driver->publicTransformToolsForResponsesApi($tools);
+
+            expect($result[0])->toHaveKey('name', 'test_tool');
+            expect($result[0])->toHaveKey('parameters');
+            expect($result[0])->not->toHaveKey('function');
+        });
+    });
+});

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesDriverTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesDriverTest.php
@@ -22,6 +22,11 @@ class TestableOpenAiResponsesDriver extends OpenAiResponsesDriver
         return $this->transformToolsForResponsesApi($tools);
     }
 
+    public function publicExtractInstructions(array $formattedInput, ?string &$instructions): array
+    {
+        return $this->extractInstructions($formattedInput, $instructions);
+    }
+
     public function getPublicFormatter(): \LarAgent\Core\Contracts\MessageFormatter
     {
         return $this->formatter;
@@ -104,6 +109,44 @@ describe('OpenAiResponsesDriver', function () {
             $payload = $this->driver->publicPreparePayload([]);
 
             expect($payload)->toHaveKey('store', true);
+        });
+
+        it('extracts system message into instructions parameter', function () {
+            $messages = [
+                new \LarAgent\Messages\SystemMessage('You are a helpful assistant.'),
+                new \LarAgent\Messages\UserMessage('Hello'),
+            ];
+
+            $payload = $this->driver->publicPreparePayload($messages);
+
+            expect($payload)->toHaveKey('instructions', 'You are a helpful assistant.');
+            // System message should be removed from input
+            foreach ($payload['input'] as $item) {
+                if (($item['type'] ?? '') === 'message') {
+                    expect($item['role'])->not->toBe('system');
+                }
+            }
+        });
+
+        it('extracts developer message into instructions parameter', function () {
+            $messages = [
+                new \LarAgent\Messages\DeveloperMessage('Be concise.'),
+                new \LarAgent\Messages\UserMessage('Hello'),
+            ];
+
+            $payload = $this->driver->publicPreparePayload($messages);
+
+            expect($payload)->toHaveKey('instructions', 'Be concise.');
+        });
+
+        it('does not set instructions when no system/developer message', function () {
+            $messages = [
+                new \LarAgent\Messages\UserMessage('Hello'),
+            ];
+
+            $payload = $this->driver->publicPreparePayload($messages);
+
+            expect($payload)->not->toHaveKey('instructions');
         });
     });
 

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
@@ -62,6 +62,25 @@ describe('OpenAiResponsesMessageFormatter', function () {
         });
     });
 
+    describe('formatMessage() with images', function () {
+        it('maps image_url content type to input_image for user messages', function () {
+            // Create a user message with multimodal content via fromArray
+            $message = UserMessage::fromArray([
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'What is in this image?'],
+                    ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/img.png']],
+                ],
+            ]);
+            $result = $this->formatter->formatMessage($message);
+
+            expect($result['content'])->toHaveCount(2);
+            expect($result['content'][0])->toBe(['type' => 'input_text', 'text' => 'What is in this image?']);
+            expect($result['content'][1]['type'])->toBe('input_image');
+            expect($result['content'][1]['image_url'])->toBe('https://example.com/img.png');
+        });
+    });
+
     describe('formatMessages()', function () {
         it('flattens ToolCallMessage into separate function_call items', function () {
             $toolCalls = [
@@ -187,6 +206,78 @@ describe('OpenAiResponsesMessageFormatter', function () {
             ];
 
             expect($this->formatter->extractFinishReason($response))->toBe('length');
+        });
+    });
+
+    describe('extractReasoningItems()', function () {
+        it('extracts reasoning items from output', function () {
+            $response = [
+                'output' => [
+                    [
+                        'id' => 'rs_abc123',
+                        'type' => 'reasoning',
+                        'content' => [],
+                        'summary' => [],
+                    ],
+                    [
+                        'type' => 'function_call',
+                        'call_id' => 'call_abc',
+                        'name' => 'get_weather',
+                        'arguments' => '{"city": "London"}',
+                    ],
+                ],
+            ];
+
+            $items = $this->formatter->extractReasoningItems($response);
+
+            expect($items)->toHaveCount(1);
+            expect($items[0]['type'])->toBe('reasoning');
+            expect($items[0]['id'])->toBe('rs_abc123');
+        });
+
+        it('returns empty array when no reasoning items', function () {
+            $response = [
+                'output' => [
+                    ['type' => 'message', 'role' => 'assistant', 'content' => []],
+                ],
+            ];
+
+            expect($this->formatter->extractReasoningItems($response))->toBeEmpty();
+        });
+    });
+
+    describe('formatMessages() with reasoning items', function () {
+        it('includes reasoning items before function_call items for ToolCallMessage', function () {
+            $toolCalls = [
+                new ToolCall('call_1', 'get_weather', '{"city": "NYC"}'),
+            ];
+            $toolCallMessage = new ToolCallMessage($toolCalls);
+            $toolCallMessage->setExtra('reasoning_items', [
+                [
+                    'id' => 'rs_abc',
+                    'type' => 'reasoning',
+                    'content' => [],
+                    'summary' => [],
+                ],
+            ]);
+
+            $result = $this->formatter->formatMessages([$toolCallMessage]);
+
+            expect($result)->toHaveCount(2);
+            expect($result[0]['type'])->toBe('reasoning');
+            expect($result[1]['type'])->toBe('function_call');
+        });
+
+        it('works without reasoning items on ToolCallMessage', function () {
+            $toolCalls = [
+                new ToolCall('call_1', 'get_weather', '{"city": "NYC"}'),
+            ];
+            $toolCallMessage = new ToolCallMessage($toolCalls);
+
+            $result = $this->formatter->formatMessages([$toolCallMessage]);
+
+            expect($result)->toHaveCount(1);
+            expect($result[0]['type'])->toBe('function_call');
         });
     });
 

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
@@ -209,76 +209,100 @@ describe('OpenAiResponsesMessageFormatter', function () {
         });
     });
 
-    describe('extractReasoningItems()', function () {
-        it('extracts reasoning items from output', function () {
-            $response = [
-                'output' => [
-                    [
-                        'id' => 'rs_abc123',
-                        'type' => 'reasoning',
-                        'content' => [],
-                        'summary' => [],
-                    ],
-                    [
-                        'type' => 'function_call',
-                        'call_id' => 'call_abc',
-                        'name' => 'get_weather',
-                        'arguments' => '{"city": "London"}',
-                    ],
-                ],
-            ];
-
-            $items = $this->formatter->extractReasoningItems($response);
-
-            expect($items)->toHaveCount(1);
-            expect($items[0]['type'])->toBe('reasoning');
-            expect($items[0]['id'])->toBe('rs_abc123');
-        });
-
-        it('strips status and other unknown fields from reasoning items', function () {
+    describe('extractOutputItemsForReplay()', function () {
+        it('extracts reasoning and function_call items from output', function () {
             $response = [
                 'output' => [
                     [
                         'id' => 'rs_abc123',
                         'type' => 'reasoning',
                         'status' => 'completed',
-                        'content' => [],
+                        'encrypted_content' => 'encrypted_data_here',
+                        'summary' => [['type' => 'summary_text', 'text' => 'thinking...']],
+                    ],
+                    [
+                        'id' => 'fc_def456',
+                        'type' => 'function_call',
+                        'status' => 'completed',
+                        'call_id' => 'call_abc',
+                        'name' => 'get_weather',
+                        'arguments' => '{"city": "London"}',
+                    ],
+                    [
+                        'type' => 'message',
+                        'role' => 'assistant',
+                        'content' => [['type' => 'output_text', 'text' => 'ignored']],
+                    ],
+                ],
+            ];
+
+            $items = $this->formatter->extractOutputItemsForReplay($response);
+
+            expect($items)->toHaveCount(2);
+            // Reasoning item - all non-null fields preserved
+            expect($items[0]['type'])->toBe('reasoning');
+            expect($items[0]['id'])->toBe('rs_abc123');
+            expect($items[0]['encrypted_content'])->toBe('encrypted_data_here');
+            expect($items[0]['status'])->toBe('completed');
+            // Function call item - all non-null fields preserved
+            expect($items[1]['type'])->toBe('function_call');
+            expect($items[1]['id'])->toBe('fc_def456');
+            expect($items[1]['call_id'])->toBe('call_abc');
+            expect($items[1]['status'])->toBe('completed');
+        });
+
+        it('filters out null values from output items', function () {
+            $response = [
+                'output' => [
+                    [
+                        'id' => 'rs_abc',
+                        'type' => 'reasoning',
+                        'encrypted_content' => null,
+                        'status' => null,
                         'summary' => [],
                     ],
                 ],
             ];
 
-            $items = $this->formatter->extractReasoningItems($response);
+            $items = $this->formatter->extractOutputItemsForReplay($response);
 
             expect($items)->toHaveCount(1);
+            expect($items[0])->not->toHaveKey('encrypted_content');
             expect($items[0])->not->toHaveKey('status');
+            expect($items[0])->toHaveKey('id', 'rs_abc');
             expect($items[0])->toHaveKey('type', 'reasoning');
-            expect($items[0])->toHaveKey('id', 'rs_abc123');
         });
 
-        it('returns empty array when no reasoning items', function () {
+        it('returns empty array when no reasoning or function_call items', function () {
             $response = [
                 'output' => [
                     ['type' => 'message', 'role' => 'assistant', 'content' => []],
                 ],
             ];
 
-            expect($this->formatter->extractReasoningItems($response))->toBeEmpty();
+            expect($this->formatter->extractOutputItemsForReplay($response))->toBeEmpty();
         });
     });
 
-    describe('formatMessages() with reasoning items', function () {
-        it('includes reasoning items before function_call items for ToolCallMessage', function () {
+    describe('formatMessages() with raw output items', function () {
+        it('replays raw output items when available on ToolCallMessage', function () {
             $toolCalls = [
                 new ToolCall('call_1', 'get_weather', '{"city": "NYC"}'),
             ];
             $toolCallMessage = new ToolCallMessage($toolCalls);
-            $toolCallMessage->setExtra('reasoning_items', [
+            $toolCallMessage->setExtra('raw_output_items', [
                 [
-                    'id' => 'rs_abc',
                     'type' => 'reasoning',
-                    'content' => [],
-                    'summary' => [],
+                    'id' => 'rs_abc',
+                    'encrypted_content' => 'encrypted_data',
+                    'summary' => [['type' => 'summary_text', 'text' => 'thinking']],
+                ],
+                [
+                    'type' => 'function_call',
+                    'id' => 'fc_def',
+                    'call_id' => 'call_1',
+                    'name' => 'get_weather',
+                    'arguments' => '{"city": "NYC"}',
                 ],
             ]);
 
@@ -286,10 +310,13 @@ describe('OpenAiResponsesMessageFormatter', function () {
 
             expect($result)->toHaveCount(2);
             expect($result[0]['type'])->toBe('reasoning');
+            expect($result[0]['id'])->toBe('rs_abc');
+            expect($result[0])->toHaveKey('encrypted_content');
             expect($result[1]['type'])->toBe('function_call');
+            expect($result[1]['id'])->toBe('fc_def');
         });
 
-        it('works without reasoning items on ToolCallMessage', function () {
+        it('falls back to reconstructed function_call items without raw output', function () {
             $toolCalls = [
                 new ToolCall('call_1', 'get_weather', '{"city": "NYC"}'),
             ];
@@ -299,6 +326,9 @@ describe('OpenAiResponsesMessageFormatter', function () {
 
             expect($result)->toHaveCount(1);
             expect($result[0]['type'])->toBe('function_call');
+            expect($result[0]['call_id'])->toBe('call_1');
+            // Reconstructed items don't have the response item id
+            expect($result[0])->not->toHaveKey('id');
         });
     });
 

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
@@ -235,6 +235,27 @@ describe('OpenAiResponsesMessageFormatter', function () {
             expect($items[0]['id'])->toBe('rs_abc123');
         });
 
+        it('strips status and other unknown fields from reasoning items', function () {
+            $response = [
+                'output' => [
+                    [
+                        'id' => 'rs_abc123',
+                        'type' => 'reasoning',
+                        'status' => 'completed',
+                        'content' => [],
+                        'summary' => [],
+                    ],
+                ],
+            ];
+
+            $items = $this->formatter->extractReasoningItems($response);
+
+            expect($items)->toHaveCount(1);
+            expect($items[0])->not->toHaveKey('status');
+            expect($items[0])->toHaveKey('type', 'reasoning');
+            expect($items[0])->toHaveKey('id', 'rs_abc123');
+        });
+
         it('returns empty array when no reasoning items', function () {
             $response = [
                 'output' => [

--- a/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
+++ b/tests/Unit/Drivers/OpenAi/OpenAiResponsesMessageFormatterTest.php
@@ -1,0 +1,231 @@
+<?php
+
+use LarAgent\Drivers\OpenAi\OpenAiResponsesMessageFormatter;
+use LarAgent\Messages\AssistantMessage;
+use LarAgent\Messages\DeveloperMessage;
+use LarAgent\Messages\SystemMessage;
+use LarAgent\Messages\ToolCallMessage;
+use LarAgent\Messages\ToolResultMessage;
+use LarAgent\Messages\UserMessage;
+use LarAgent\ToolCall;
+
+beforeEach(function () {
+    $this->formatter = new OpenAiResponsesMessageFormatter;
+});
+
+describe('OpenAiResponsesMessageFormatter', function () {
+    describe('formatMessage()', function () {
+        it('formats a UserMessage as Responses API input item', function () {
+            $message = new UserMessage('Hello');
+            $result = $this->formatter->formatMessage($message);
+
+            expect($result)->toHaveKey('type', 'message');
+            expect($result)->toHaveKey('role', 'user');
+            expect($result['content'])->toBeArray();
+            expect($result['content'][0])->toBe(['type' => 'input_text', 'text' => 'Hello']);
+        });
+
+        it('formats a SystemMessage with input_text content type', function () {
+            $message = new SystemMessage('You are helpful.');
+            $result = $this->formatter->formatMessage($message);
+
+            expect($result)->toHaveKey('type', 'message');
+            expect($result)->toHaveKey('role', 'system');
+            expect($result['content'][0])->toBe(['type' => 'input_text', 'text' => 'You are helpful.']);
+        });
+
+        it('formats a DeveloperMessage with input_text content type', function () {
+            $message = new DeveloperMessage('Be concise.');
+            $result = $this->formatter->formatMessage($message);
+
+            expect($result)->toHaveKey('type', 'message');
+            expect($result)->toHaveKey('role', 'developer');
+            expect($result['content'][0])->toBe(['type' => 'input_text', 'text' => 'Be concise.']);
+        });
+
+        it('formats an AssistantMessage with output_text content type', function () {
+            $message = new AssistantMessage('Sure, I can help.');
+            $result = $this->formatter->formatMessage($message);
+
+            expect($result)->toHaveKey('type', 'message');
+            expect($result)->toHaveKey('role', 'assistant');
+            expect($result['content'][0])->toBe(['type' => 'output_text', 'text' => 'Sure, I can help.']);
+        });
+
+        it('formats a ToolResultMessage as function_call_output', function () {
+            $message = new ToolResultMessage('{"result": "ok"}', 'call_123', 'tool_name');
+            $result = $this->formatter->formatMessage($message);
+
+            expect($result)->toHaveKey('type', 'function_call_output');
+            expect($result)->toHaveKey('call_id', 'call_123');
+            expect($result)->toHaveKey('output');
+        });
+    });
+
+    describe('formatMessages()', function () {
+        it('flattens ToolCallMessage into separate function_call items', function () {
+            $toolCalls = [
+                new ToolCall('call_1', 'get_weather', '{"city": "NYC"}'),
+                new ToolCall('call_2', 'get_time', '{"zone": "EST"}'),
+            ];
+            $toolCallMessage = new ToolCallMessage($toolCalls);
+
+            $result = $this->formatter->formatMessages([$toolCallMessage]);
+
+            expect($result)->toHaveCount(2);
+            expect($result[0])->toHaveKey('type', 'function_call');
+            expect($result[0])->toHaveKey('call_id', 'call_1');
+            expect($result[0])->toHaveKey('name', 'get_weather');
+            expect($result[0])->toHaveKey('arguments', '{"city": "NYC"}');
+            expect($result[1])->toHaveKey('type', 'function_call');
+            expect($result[1])->toHaveKey('call_id', 'call_2');
+            expect($result[1])->toHaveKey('name', 'get_time');
+        });
+
+        it('formats mixed message types correctly', function () {
+            $messages = [
+                new SystemMessage('You are helpful.'),
+                new UserMessage('Hello'),
+                new AssistantMessage('Hi there!'),
+            ];
+
+            $result = $this->formatter->formatMessages($messages);
+
+            expect($result)->toHaveCount(3);
+            expect($result[0]['role'])->toBe('system');
+            expect($result[1]['role'])->toBe('user');
+            expect($result[2]['role'])->toBe('assistant');
+        });
+    });
+
+    describe('extractToolCalls()', function () {
+        it('extracts function_call items from output', function () {
+            $response = [
+                'output' => [
+                    [
+                        'type' => 'function_call',
+                        'call_id' => 'call_abc',
+                        'name' => 'get_weather',
+                        'arguments' => '{"city": "London"}',
+                    ],
+                    [
+                        'type' => 'message',
+                        'role' => 'assistant',
+                        'content' => [['type' => 'output_text', 'text' => 'Let me check.']],
+                    ],
+                    [
+                        'type' => 'function_call',
+                        'call_id' => 'call_def',
+                        'name' => 'get_time',
+                        'arguments' => '{"zone": "UTC"}',
+                    ],
+                ],
+            ];
+
+            $toolCalls = $this->formatter->extractToolCalls($response);
+
+            expect($toolCalls)->toHaveCount(2);
+            expect($toolCalls[0]->getId())->toBe('call_abc');
+            expect($toolCalls[0]->getToolName())->toBe('get_weather');
+            expect($toolCalls[0]->getArguments())->toBe('{"city": "London"}');
+            expect($toolCalls[1]->getId())->toBe('call_def');
+            expect($toolCalls[1]->getToolName())->toBe('get_time');
+        });
+
+        it('returns empty array when no function_call items', function () {
+            $response = [
+                'output' => [
+                    ['type' => 'message', 'role' => 'assistant', 'content' => []],
+                ],
+            ];
+
+            expect($this->formatter->extractToolCalls($response))->toBeEmpty();
+        });
+    });
+
+    describe('extractContent()', function () {
+        it('extracts output_text from response', function () {
+            $response = [
+                'output_text' => 'Hello, how can I help?',
+            ];
+
+            expect($this->formatter->extractContent($response))->toBe('Hello, how can I help?');
+        });
+
+        it('returns empty string when output_text is missing', function () {
+            expect($this->formatter->extractContent([]))->toBe('');
+        });
+    });
+
+    describe('extractFinishReason()', function () {
+        it('returns tool_calls when output contains function_call items', function () {
+            $response = [
+                'status' => 'completed',
+                'output' => [
+                    ['type' => 'function_call', 'call_id' => 'call_1', 'name' => 'test', 'arguments' => '{}'],
+                ],
+            ];
+
+            expect($this->formatter->extractFinishReason($response))->toBe('tool_calls');
+        });
+
+        it('maps completed status to stop', function () {
+            $response = [
+                'status' => 'completed',
+                'output' => [
+                    ['type' => 'message', 'role' => 'assistant'],
+                ],
+            ];
+
+            expect($this->formatter->extractFinishReason($response))->toBe('stop');
+        });
+
+        it('maps incomplete status to length', function () {
+            $response = [
+                'status' => 'incomplete',
+                'output' => [],
+            ];
+
+            expect($this->formatter->extractFinishReason($response))->toBe('length');
+        });
+    });
+
+    describe('extractUsage()', function () {
+        it('maps input_tokens and output_tokens to normalized keys', function () {
+            $response = [
+                'usage' => [
+                    'input_tokens' => 100,
+                    'output_tokens' => 50,
+                    'total_tokens' => 150,
+                ],
+            ];
+
+            $usage = $this->formatter->extractUsage($response);
+
+            expect($usage['prompt_tokens'])->toBe(100);
+            expect($usage['completion_tokens'])->toBe(50);
+            expect($usage['total_tokens'])->toBe(150);
+        });
+
+        it('computes total_tokens if missing', function () {
+            $response = [
+                'usage' => [
+                    'input_tokens' => 80,
+                    'output_tokens' => 20,
+                ],
+            ];
+
+            $usage = $this->formatter->extractUsage($response);
+
+            expect($usage['total_tokens'])->toBe(100);
+        });
+
+        it('returns zeros when usage is missing', function () {
+            $usage = $this->formatter->extractUsage([]);
+
+            expect($usage['prompt_tokens'])->toBe(0);
+            expect($usage['completion_tokens'])->toBe(0);
+            expect($usage['total_tokens'])->toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
- Add `OpenAiResponsesDriver` for the OpenAI Responses API (`/v1/responses`), needed for newer models (e.g. `gpt-5.4-mini`) that require this API when using function tools with `reasoning_effort`
- Add `OpenAiResponsesMessageFormatter` handling the different input/output format (flat `function_call` items, `input_text`/`output_text` content types, `input_tokens`/`output_tokens` usage mapping)
- Add `OpenAiResponsesCompatible` for third-party providers with Responses-API-compatible endpoints
- Add `openai_responses` provider entry in default config

Key differences from Chat Completions driver:
- `input` instead of `messages`
- `max_output_tokens` instead of `max_completion_tokens`
- `reasoning.effort` mapped from `reasoning_effort` extra
- `text.format` for structured output instead of `response_format`
- Flat tool format (no `function` wrapper) with strict mode
- Streaming via typed SSE events (`response.output_text.delta`, `response.output_item.added`, etc.)

Extends `BaseOpenAiDriver` to reuse ~300 lines of strict-mode schema transformation code.

## Test plan

- [x] All 1055 existing tests pass
- [x] 17 new formatter tests (message formatting, tool call extraction, usage mapping, finish reason detection)
- [x] 8 new driver tests (payload structure, reasoning_effort mapping, tool format, structured output)
- [x] Manual test with an agent configured to use `OpenAiResponsesDriver` with basic text
- [x] Manual test with an agent configured to use `OpenAiResponsesDriver` with tools
- [x] Manual test with an agent configured to use `OpenAiResponsesDriver` with structured output
- [x] Manual test with an agent configured to use `OpenAiResponsesDriver` with streaming
